### PR TITLE
required for body scroll block on drawer/popup opening

### DIFF
--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -54,6 +54,7 @@ let%client remove_class elt str =
   let body = Of_dom.of_body Dom_html.document##.body in
   Manip.Class.remove elt str;
   Manip.Class.remove body @@ "dr-drawer-" ^ str
+let%client body = Of_dom.of_body Dom_html.document##.body
 
 (* Returns [(drawer, open_drawer, close_drawer)]
  * [ drawer ] DOM element

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -63,7 +63,7 @@ let%client add_class elt str =
 let%client remove_class elt str =
   let body = Of_dom.of_body Dom_html.document##.body in
   Manip.Class.remove elt str;
-  html_Manip_class_remove @@ "dr-drawer-" ^ str
+  html_ManipClass_remove @@ "dr-drawer-" ^ str
 
 (* Returns [(drawer, open_drawer, close_drawer)]
  * [ drawer ] DOM element
@@ -92,7 +92,11 @@ let%shared drawer ?(a = []) ?(position = `Left)
 
   let close = [%client
     ((fun () ->
-       remove_class ~%bckgrnd "open";
+       if ~%ios_scroll_pos_fix then
+         let scrollpos = Dom_html.document##.body##.scrollTop in
+         remove_class ~%bckgrnd "open";
+         Dom_html.document##.body##.scrollTop := scrollpos
+       else remove_class ~%bckgrnd "open";
        add_class ~%bckgrnd "closing";
        Lwt.cancel !(~%touch_thread);
        unbind_click_outside ();
@@ -117,7 +121,7 @@ let%shared drawer ?(a = []) ?(position = `Left)
            let scrollpos = Dom_html.document##.body##.scrollTop in
            remove_class ~%bckgrnd "open";
            Dom_html.document##.body##.scrollTop := scrollpos
-         else remove_class ~%bckgrnd "dr-drawer-open";
+         else remove_class ~%bckgrnd "open";
          Lwt.return ()))
      : unit -> unit)]
   in

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -46,21 +46,31 @@ let%client unbind_click_outside, bind_click_outside =
      in
      r := th)
 
+let%client html () = Js.Opt.to_option @@
+  Js.Opt.map (Dom_html.CoerceTo.html Dom_html.document##.documentElement)
+    Of_dom.of_html
+let%client html_ManipClass_add cl = match html () with
+  | Some html -> Manip.Class.add html cl
+  | None -> ()
+let%client html_ManipClass_remove cl = match html () with
+  | Some html -> Manip.Class.remove html cl
+  | None -> ()
+
 let%client add_class elt str =
   let body = Of_dom.of_body Dom_html.document##.body in
   Manip.Class.add elt str;
-  Manip.Class.add body @@ "dr-drawer-" ^ str
+  html_ManipClass_add @@ "dr-drawer-" ^ str
 let%client remove_class elt str =
   let body = Of_dom.of_body Dom_html.document##.body in
   Manip.Class.remove elt str;
-  Manip.Class.remove body @@ "dr-drawer-" ^ str
-let%client body = Of_dom.of_body Dom_html.document##.body
+  html_Manip_class_remove @@ "dr-drawer-" ^ str
 
 (* Returns [(drawer, open_drawer, close_drawer)]
  * [ drawer ] DOM element
  * [ open_drawer ] function to open the drawer
  * [ close_drawer ] function to close the drawer *)
-let%shared drawer ?(a = []) ?(position = `Left) content =
+let%shared drawer ?(a = []) ?(position = `Left)
+    ?(ios_scroll_pos_fix=true) content =
   let a = (a :> Html_types.div_attrib attrib list) in
   let toggle_button =
     D.Form.button_no_value

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -132,6 +132,13 @@ let%shared drawer ?(a = []) ?(position = `Left)
      : unit -> unit)]
   in
 
+  let _ = [%client ((Eliom_client.onunload @@ fun () ->
+    html_ManipClass_remove "dr-drawer-opening";
+    html_ManipClass_remove "dr-drawer-open";
+    html_ManipClass_remove "dr-drawer-closing";
+    None
+  ):unit)] in
+
   let _ = [%client
     (let toggle () =
        if Manip.Class.contain ~%bckgrnd "open"

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -113,6 +113,11 @@ let%shared drawer ?(a = []) ?(position = `Left)
        Lwt_js_events.async (fun () ->
          let%lwt () = Lwt_js_events.transitionend (To_dom.of_element ~%d) in
          remove_class ~%bckgrnd "opening";
+         if ~%ios_scroll_pos_fix then
+           let scrollpos = Dom_html.document##.body##.scrollTop in
+           remove_class ~%bckgrnd "open";
+           Dom_html.document##.body##.scrollTop := scrollpos
+         else remove_class ~%bckgrnd "dr-drawer-open";
          Lwt.return ()))
      : unit -> unit)]
   in

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -94,11 +94,9 @@ let%shared drawer ?(a = []) ?(position = `Left)
 
   let close = [%client
     ((fun () ->
+       remove_class ~%bckgrnd "open";
        if ~%ios_scroll_pos_fix then
-         let scrollpos = Dom_html.document##.body##.scrollTop in
-         remove_class ~%bckgrnd "open";
          Dom_html.document##.body##.scrollTop := !scroll_pos;
-       else remove_class ~%bckgrnd "open";
        add_class ~%bckgrnd "closing";
        Lwt.cancel !(~%touch_thread);
        unbind_click_outside ();
@@ -123,11 +121,6 @@ let%shared drawer ?(a = []) ?(position = `Left)
        Lwt_js_events.async (fun () ->
          let%lwt () = Lwt_js_events.transitionend (To_dom.of_element ~%d) in
          remove_class ~%bckgrnd "opening";
-         if ~%ios_scroll_pos_fix then
-           let scrollpos = Dom_html.document##.body##.scrollTop in
-           remove_class ~%bckgrnd "open";
-           Dom_html.document##.body##.scrollTop := scrollpos
-         else remove_class ~%bckgrnd "open";
          Lwt.return ()))
      : unit -> unit)]
   in

--- a/src/widgets/ot_drawer.eliom
+++ b/src/widgets/ot_drawer.eliom
@@ -65,6 +65,8 @@ let%client remove_class elt str =
   Manip.Class.remove elt str;
   html_ManipClass_remove @@ "dr-drawer-" ^ str
 
+let%client scroll_pos = ref 0
+
 (* Returns [(drawer, open_drawer, close_drawer)]
  * [ drawer ] DOM element
  * [ open_drawer ] function to open the drawer
@@ -95,7 +97,7 @@ let%shared drawer ?(a = []) ?(position = `Left)
        if ~%ios_scroll_pos_fix then
          let scrollpos = Dom_html.document##.body##.scrollTop in
          remove_class ~%bckgrnd "open";
-         Dom_html.document##.body##.scrollTop := scrollpos
+         Dom_html.document##.body##.scrollTop := !scroll_pos;
        else remove_class ~%bckgrnd "open";
        add_class ~%bckgrnd "closing";
        Lwt.cancel !(~%touch_thread);
@@ -109,7 +111,11 @@ let%shared drawer ?(a = []) ?(position = `Left)
 
   let open_ = [%client
     ((fun () ->
+       if ~%ios_scroll_pos_fix then
+         scroll_pos := Dom_html.document##.body##.scrollTop;
        add_class ~%bckgrnd "open";
+       if ~%ios_scroll_pos_fix then
+         Dom_html.document##.body##.scrollTop := !scroll_pos;
        add_class ~%bckgrnd "opening";
        Lwt.cancel !(~%touch_thread);
        !(~%bind_touch) ();

--- a/src/widgets/ot_drawer.eliomi
+++ b/src/widgets/ot_drawer.eliomi
@@ -26,10 +26,17 @@
     Returns the DOM element, and functions to open and close the menu.
     It is also possible to open or close the menu by clicking on a button,
     and to swipe the menu to close it.
+    If [ios_scroll_pos_fix] is true (default) each time after the drawer is
+    opened, the scroll position of the document body is set to the value it
+    had just before opening the drawer. This is a workaround for a bug in iOS
+    mobile where if one prevents document scrolling by CSS (requires on iOS the
+    CSS code: html.dr-drawer-open, html.dr-drawer-open>body {overflow: hidden})
+    the document is scrolled to the top.
 *)
 val drawer :
   ?a:[< Html_types.div_attrib] Eliom_content.Html.attrib list ->
   ?position:[ `Left | `Right ] ->
+  ?ios_scroll_pos_fix:bool ->
   [< Html_types.div_content] Eliom_content.Html.elt list ->
   [> `Div ] Eliom_content.Html.elt *
   (unit -> unit) Eliom_client_value.t *

--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -77,7 +77,13 @@ let%client popup
 
   let do_close () =
     decr number_of_popups;
-    if !number_of_popups = 0 then html_ManipClass_remove "ot-with-popup";
+    if !number_of_popups = 0 then begin
+      if ios_scroll_pos_fix then
+        let scrollpos = Dom_html.document##.body##.scrollTop in
+        html_ManipClass_remove "ot-with-popup";
+        Dom_html.document##.body##.scrollTop := scrollpos
+      else html_ManipClass_remove "ot-with-popup"
+    end;
     let () = Eliom_lib.Option.iter Manip.removeSelf !popup in
     onclose ()
   in

--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -31,6 +31,8 @@ let%shared hcf ?(a=[]) ?(header=[]) ?(footer=[]) content =
 
 let%client number_of_popups = ref 0
 
+let%client scroll_pos = ref 0
+
 let%client popup
     ?(a = [])
     ?close_button
@@ -69,20 +71,16 @@ let%client popup
     | None -> ()
   in
 
-  if ios_scroll_pos_fix then
-    let scrollpos = Dom_html.document##.body##.scrollTop in
-    html_ManipClass_add "ot-with-popup";
-    Dom_html.document##.body##.scrollTop := scrollpos
-  else html_ManipClass_add "ot-with-popup";
+  if ios_scroll_pos_fix then scroll_pos := Dom_html.document##.body##.scrollTop;
+  html_ManipClass_add "ot-with-popup";
+  if ios_scroll_pos_fix then Dom_html.document##.body##.scrollTop := !scroll_pos;
 
   let do_close () =
     decr number_of_popups;
     if !number_of_popups = 0 then begin
+      html_ManipClass_remove "ot-with-popup";
       if ios_scroll_pos_fix then
-        let scrollpos = Dom_html.document##.body##.scrollTop in
-        html_ManipClass_remove "ot-with-popup";
-        Dom_html.document##.body##.scrollTop := scrollpos
-      else html_ManipClass_remove "ot-with-popup"
+        Dom_html.document##.body##.scrollTop := !scroll_pos
     end;
     let () = Eliom_lib.Option.iter Manip.removeSelf !popup in
     onclose ()

--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -86,6 +86,11 @@ let%client popup
     onclose ()
   in
 
+  begin Eliom_client.onunload @@ fun () ->
+    html_ManipClass_remove "ot-with-popup";
+    None
+  end;
+
   let close () =
     match confirmation_onclose with
     | None -> do_close ()

--- a/src/widgets/ot_popup.eliomi
+++ b/src/widgets/ot_popup.eliomi
@@ -49,12 +49,14 @@ val hcf :
     [closeable].
     [onclose] is a hook called just after the popup has been actually closed.
     [gen_content] is a function taking the function closing the popup as
-    parameter, and returning the popup content. *)
+    parameter, and returning the popup content.
+    For [ios_scroll_pos_fix] see [Ot_drawer.drawer] *)
 val popup :
   ?a:[< div_attrib ] attrib list
   -> ?close_button:(button_content elt list)
   -> ?confirmation_onclose:(unit -> bool Lwt.t)
   -> ?onclose:(unit -> unit Lwt.t)
+  -> ?ios_scroll_pos_fix:bool
   -> ((unit -> unit Lwt.t) -> [< div_content ] elt Lwt.t)
   -> [> `Div ] elt Lwt.t
 


### PR DESCRIPTION
- notify html-element of popup/drawer opening
- workaround for weird scroll behaviour in iOS when preventing the body to scroll