### PR TITLE
reworked position:sticky-polyfill

### DIFF
--- a/css/ot_sticky.css
+++ b/css/ot_sticky.css
@@ -1,7 +1,15 @@
-.ot-sticky.ot-stuck {
+.ot-sticky-fixed {
     position: fixed;
 }
-
-.ot-sticky-placeholder {
+.ot-sticky-fixed:not(.ot-stuck) {
     visibility: hidden;
 }
+
+.ot-sticky-inline.ot-stuck {
+    visibility: hidden;
+}
+
+// .ot-sticky-inline:not(.ot-stuck) {
+//     height: 0 !important;
+//     // display: none;
+// }

--- a/css/ot_sticky.css
+++ b/css/ot_sticky.css
@@ -8,8 +8,3 @@
 .ot-sticky-inline.ot-stuck {
     visibility: hidden;
 }
-
-// .ot-sticky-inline:not(.ot-stuck) {
-//     height: 0 !important;
-//     // display: none;
-// }

--- a/opam/opam
+++ b/opam/opam
@@ -5,7 +5,7 @@ homepage: "http://www.ocsigen.org"
 bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
 dev-repo: "https://github.com/ocsigen/ocsigen-toolkit.git"
 version: "dev"
-build: [ make ]
+build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]
 depends: [

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -148,8 +148,8 @@ let dissolve g =
 
 type leash = {thread: unit Lwt.t; glue: glue option}
 
-let keep_in_sight ~dir elt =
-  let%lwt glue = make_sticky ~dir elt in
+let keep_in_sight ~dir ?ios_html_scroll_hack elt =
+  let%lwt glue = make_sticky ?ios_html_scroll_hack ~dir elt in
   let elt = match glue with
     | None -> elt
     | Some g -> g.fixed

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -150,10 +150,7 @@ type leash = {thread: unit Lwt.t; glue: glue option}
 
 let keep_in_sight ~dir ?ios_html_scroll_hack elt =
   let%lwt glue = make_sticky ?ios_html_scroll_hack ~dir elt in
-  let elt = match glue with
-    | None -> elt
-    | Some g -> g.fixed
-  in
+  let elt = match glue with | None -> elt | Some g -> g.fixed in
   let sight_thread = match dir with
   | `Top -> begin
     let%lwt () = Ot_nodeready.nodeready (To_dom.of_element elt) in

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -31,8 +31,6 @@ let supports_position_sticky elt =
 let is_sticky elt =
   is_position_sticky elt || Manip.Class.contain elt "ot-sticky-inline"
 
-(*TODO: Everything with *Px is rounded to pixels. We don't want this*)
-
 type glue = {
   fixed : div_content D.elt;
   inline : div_content D.elt;
@@ -97,7 +95,6 @@ let update_state ?force g =
   | `Left -> if Ot_size.client_left fixed > Ot_size.client_left inline
                then stick ?force g else unstick ?force g
 
-(*TODO: doc: should be a D element*)
 let make_sticky
     ~dir (* TODO: detect based on CSS attribute? *)
     (*TODO: `Bottom and `Right *)
@@ -148,9 +145,6 @@ let dissolve g =
 
 type leash = {thread: unit Lwt.t; glue: glue option}
 
-(** Make sure a sticky element never scrolls out of view by dynamically
-    modifying the CSS attribute "top" *)
-    (* TODO: doc: kill the thread to cancel the effects *)
 let keep_in_sight ~dir elt =
   let glue = make_sticky ~dir elt in
   let elt = match glue with

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -79,23 +79,28 @@ let fix_size_pos g =
     | `Left -> Ot_style.set_top g.fixed @@ Ot_size.client_page_top  fixed
   end
 
-let stick g =
+let stick g = if not @@ Manip.Class.contain g.fixed "ot-stuck" then begin
   Manip.Class.add g.fixed "ot-stuck";
   Manip.Class.add g.inline "ot-stuck"
+end
 
-let detach g =
+let detach g = if Manip.Class.contain g.fixed "ot-stuck" then begin
   Manip.Class.remove g.fixed "ot-stuck";
   Manip.Class.remove g.inline "ot-stuck"
+end
 
 let update_state g =
   let fixed = To_dom.of_element g.fixed in
   let inline = To_dom.of_element g.inline in
   match g.dir with
-  | `Top -> if Ot_size.client_top fixed > Ot_size.client_top inline
+  | `Top ->
+    print_endline @@ string_of_float (Ot_size.client_top fixed) ^ " " ^ string_of_float (Ot_size.client_top inline);
+    if Ot_size.client_top fixed > Ot_size.client_top inline
               then stick g else detach g
   | `Left -> if Ot_size.client_left fixed > Ot_size.client_left inline
                then stick g else detach g
 
+(*TODO: doc: should be a D element*)
 let make_sticky
     ~dir (* TODO: detect based on CSS attribute? *)
     (*TODO: `Bottom and `Right *)
@@ -108,7 +113,7 @@ let make_sticky
     elt = if supports_position_sticky elt then None else
   let inline = Js.Opt.case
       (Dom.CoerceTo.element @@ (To_dom.of_element elt)##cloneNode Js._true)
-    (fun () -> failwith "muh")
+      (fun () -> failwith "could not clone element to make it sticky")
     (fun x -> x)
   in
   let inline = Of_dom.of_element @@ Dom_html.element inline in

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -21,17 +21,11 @@ val is_sticky : 'a elt -> bool
     derived from the inline other element, meaning from the inline for
     the element fixed, and from fixed for the inline.
 *)
-type set_size = [ `Fix | `Leave | `Sync ]
 
 type glue = {
   fixed : div_content D.elt;
   inline : div_content D.elt;
   dir : [`Top | `Left];
-  pos: set_size;
-  inline_width: set_size;
-  inline_height: set_size;
-  fixed_width: set_size;
-  fixed_height: set_size;
   scroll_thread: unit Lwt.t;
   resize_thread: unit Lwt.t;
 }
@@ -50,11 +44,6 @@ type glue = {
 *)
 val make_sticky :
   dir:[ `Left | `Top ] ->
-  ?inline_width:set_size ->
-  ?inline_height:set_size ->
-  ?fixed_width:set_size ->
-  ?fixed_height:set_size ->
-  ?pos:set_size ->
   ?ios_html_scroll_hack:bool ->
   div_content elt -> glue option
 

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -41,7 +41,7 @@ type glue = {
 val make_sticky :
   dir:[ `Left | `Top ] ->
   ?ios_html_scroll_hack:bool ->
-  div_content elt -> glue option
+  div_content elt -> glue option Lwt.t
 
 (** stop element from being sticky *)
 val dissolve : glue -> unit
@@ -53,7 +53,7 @@ type leash = {thread: unit Lwt.t; glue: glue option}
     the top/left value. Calls [make_sticky]. Make sure to also apply the CSS
     code "position: sticky" to the element.
 *)
-val keep_in_sight : dir:[ `Left | `Top ] -> div_content elt -> leash option
+val keep_in_sight : dir:[`Left | `Top] -> div_content elt -> leash Lwt.t
 
-(** stop element from being in sight (and also sticky) *)
+(** stop element from being in sight (also stops the sticky polyfill) *)
 val release : leash -> unit

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -15,45 +15,45 @@ val supports_position_sticky : 'a elt -> bool
 val is_sticky : 'a elt -> bool
 
 (** determines how certain values of [make_sticky] are computed
-    [`Fix] sets the value to a fixed length when the element get stuck.
+    [`Fix] sets the value to a inline length when the element get stuck.
     With [`Leave] the value is not touched at all.
     [`Sync] causes the value to continuously (on window scroll/resize) be
-    derived from the placeholder other element, meaning from the placeholder for
-    the element elt, and from elt fro the placeholder.
+    derived from the inline other element, meaning from the inline for
+    the element fixed, and from fixed for the inline.
 *)
 type set_size = [ `Fix | `Leave | `Sync ]
 
 type glue = {
-  elt : div_content D.elt;
-  placeholder : div_content D.elt;
+  fixed : div_content D.elt;
+  inline : div_content D.elt;
   dir : [`Top | `Left];
   pos: set_size;
-  placeholder_width: set_size;
-  placeholder_height: set_size;
-  elt_width: set_size;
-  elt_height: set_size;
+  inline_width: set_size;
+  inline_height: set_size;
+  fixed_width: set_size;
+  fixed_height: set_size;
   scroll_thread: unit Lwt.t;
   resize_thread: unit Lwt.t;
 }
 
 (** polyfill for the value "sticky" of the CSS position attribute which is not
-    supported by Chrome. It functions by creating a clone ("placeholder") of the
+    supported by Chrome. It functions by creating a clone ("inline") of the
     designated element and continuously (window scroll/resize) monitoring the
-    position of the element and the placeholder.
-    [placeholder_width], [placeholder_height], [elt_width], [elt_height]
-    determine the size of the placeholder and the element while the element is
+    position of the element and the inline.
+    [inline_width], [inline_height], [fixed_width], [fixed_height]
+    determine the size of the inline and the element while the element is
     stuck; be careful not to create cycles (e.g. [`Fix] for both
-    [placeholder_width] and [elt_width]).
+    [inline_width] and [fixed_width]).
     Make sure to also apply the CSS code "position: sticky" to the element as
     this function has no effect if "position: sticky" is supported by the
     browser (TODO)
 *)
 val make_sticky :
   dir:[ `Left | `Top ] ->
-  ?placeholder_width:set_size ->
-  ?placeholder_height:set_size ->
-  ?elt_width:set_size ->
-  ?elt_height:set_size ->
+  ?inline_width:set_size ->
+  ?inline_height:set_size ->
+  ?fixed_width:set_size ->
+  ?fixed_height:set_size ->
   ?pos:set_size ->
   ?ios_html_scroll_hack:bool ->
   div_content elt -> glue option

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -30,17 +30,13 @@ type glue = {
   resize_thread: unit Lwt.t;
 }
 
-(** polyfill for the value "sticky" of the CSS position attribute which is not
-    supported by Chrome. It functions by creating a clone ("inline") of the
-    designated element and continuously (window scroll/resize) monitoring the
-    position of the element and the inline.
-    [inline_width], [inline_height], [fixed_width], [fixed_height]
-    determine the size of the inline and the element while the element is
-    stuck; be careful not to create cycles (e.g. [`Fix] for both
-    [inline_width] and [fixed_width]).
-    Make sure to also apply the CSS code "position: sticky" to the element as
-    this function has no effect if "position: sticky" is supported by the
-    browser (TODO)
+(** position:sticky polyfill which is not supported by Chrome. It functions by
+    making a clone with position:fixed of the designated element and
+    continuously (window scroll/resize) monitoring the position of the element
+    and the clone. The contents of the element is shifted back and forth between
+    the two elements. Make sure to also apply the CSS code "position: sticky" to
+    the element as this function has no effect if "position: sticky" is
+    supported by the browser. The supplied element should be a D-element.
 *)
 val make_sticky :
   dir:[ `Left | `Top ] ->

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -41,7 +41,8 @@ type glue = {
 val make_sticky :
   dir:[ `Left | `Top ] ->
   ?ios_html_scroll_hack:bool ->
-  div_content elt -> glue option Lwt.t
+  div_content elt ->
+  glue option Lwt.t
 
 (** stop element from being sticky *)
 val dissolve : glue -> unit
@@ -53,7 +54,11 @@ type leash = {thread: unit Lwt.t; glue: glue option}
     the top/left value. Calls [make_sticky]. Make sure to also apply the CSS
     code "position: sticky" to the element.
 *)
-val keep_in_sight : dir:[`Left | `Top] -> div_content elt -> leash Lwt.t
+val keep_in_sight :
+  dir:[`Left | `Top] ->
+  ?ios_html_scroll_hack:bool ->
+  div_content elt ->
+  leash Lwt.t
 
 (** stop element from being in sight (also stops the sticky polyfill) *)
 val release : leash -> unit

--- a/src/widgets/ot_style.eliom
+++ b/src/widgets/ot_style.eliom
@@ -30,7 +30,7 @@ let parse_px str =
   with Invalid_argument _ | Match_failure _ -> None
 
 let float_of_px str = match parse_px str with | None -> 0.0 | Some x -> x
-let px_of_float px = string_of_float px ^ "px"
+let px_of_float px = string_of_float px ^ "0px"
 
 let style elt = Dom_html.window##getComputedStyle elt
 


### PR DESCRIPTION
works well now, as far as I can see.
Main change is that instead of "deep cloning" the element its children are moved back and forth between the fixed and the inline element. Otherwise all the javascript code is broken.