### PR TITLE
fix initialisation of position:sticky-polyfill (also pull bs)

### DIFF
--- a/src/widgets/ot_lib.eliom
+++ b/src/widgets/ot_lib.eliom
@@ -19,6 +19,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+let%client onloads handler =
+  let rec loop () = Eliom_client.onload @@ fun () -> handler (); loop () in loop ()
 
 let%client onresizes handler =
   let thread = Lwt_js_events.onresizes handler in

--- a/src/widgets/ot_lib.eliomi
+++ b/src/widgets/ot_lib.eliomi
@@ -21,6 +21,7 @@
 
 [%%client.start]
 
+val onloads : (unit -> unit) -> unit
 (** NOTE: be careful when using the functions [onresizes], [window_scroll], and
     [window_scrolls]. They may be called before the new document is displayed
     (and thus the new window is there) and therefore may be attached to the

--- a/src/widgets/ot_spinner.eliom
+++ b/src/widgets/ot_spinner.eliom
@@ -56,7 +56,7 @@ let onloaded, set_onloaded = React.E.create ()
 (* Make sure the signal is not destroyed indirectly
    by a call to React.E.stop *)
 let _ = ignore (React.E.map (fun _ -> ()) onloaded)
-let _ = Eliom_client.onload @@ fun () ->
+let _ = Ot_lib.onloads @@ fun () ->
   if React.S.value num_active_spinners = 0 then set_onloaded ()
 let inc_active_spinners () =
   set_num_active_spinners @@ React.S.value num_active_spinners + 1

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -120,9 +120,9 @@ let make_sticky
       dir = dir;
       dissolve = fun () -> failwith "undefined"
     } in
-    let onloaded_thread = Ot_spinner.onloaded |> React.E.map @@
-      fun () -> unstick ~force:true glue; synchronise glue; update_state glue
-    in
+    let init () = unstick ~force:true glue; synchronise glue; update_state glue in
+    init ();
+    let onloaded_thread = Ot_spinner.onloaded |> React.E.map init in
     let scroll_thread = Ot_lib.window_scrolls ~ios_html_scroll_hack @@ fun _ _ ->
       update_state glue; Lwt.return ()
     in

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -36,8 +36,7 @@ type glue = {
   fixed : div_content D.elt;
   inline : div_content D.elt;
   dir : [`Top | `Left]; (*TODO: support `Bottom and `Right*)
-  scroll_thread: unit Lwt.t;
-  resize_thread: unit Lwt.t;
+  dissolve : unit -> unit
 }
 
 let move_content ~from to_elt =
@@ -119,30 +118,28 @@ let make_sticky
       fixed = fixed;
       inline = elt;
       dir = dir;
-      scroll_thread = Lwt.return ();
-      resize_thread = Lwt.return ();
+      dissolve = fun () -> failwith "undefined"
     } in
-    let lt =
-      Ot_spinner.onloaded |> React.E.map @@ fun () -> Lwt.async @@ fun () ->
-        synchronise glue; update_state ~force:true glue; Lwt.return ()
+    let onloaded_thread = Ot_spinner.onloaded |> React.E.map @@
+      fun () -> unstick ~force:true glue; synchronise glue; update_state glue
     in
-    let st = Ot_lib.window_scrolls ~ios_html_scroll_hack @@ fun _ _ ->
+    let scroll_thread = Ot_lib.window_scrolls ~ios_html_scroll_hack @@ fun _ _ ->
       update_state glue; Lwt.return ()
     in
-    let rt = Ot_lib.onresizes @@ fun _ _ ->
+    let resize_thread = Ot_lib.onresizes @@ fun _ _ ->
       synchronise glue; update_state glue; Lwt.return ()
     in
-    Eliom_client.onunload (fun () ->
-      Lwt.cancel st; Lwt.cancel rt; React.E.stop ~strong:true lt; None);
-    Lwt.return @@ Some {glue with scroll_thread = st; resize_thread = rt}
+    let dissolve () =
+      Lwt.cancel scroll_thread;
+      Lwt.cancel resize_thread;
+      React.E.stop onloaded_thread;
+      unstick ~force:true glue;
+      Manip.removeSelf glue.fixed;
+      Manip.Class.remove glue.inline "ot-sticky-inline"
+    in
+    Eliom_client.onunload (fun () -> dissolve (); None);
+    Lwt.return @@ Some {glue with dissolve = dissolve}
   end
-
-let dissolve g =
-  Lwt.cancel g.scroll_thread;
-  Lwt.cancel g.resize_thread;
-  unstick ~force:true g;
-  Manip.removeSelf g.fixed;
-  Manip.Class.remove g.inline "ot-sticky-inline"
 
 (* This is about functionality built on top of position:sticky / the polyfill *)
 
@@ -167,16 +164,13 @@ let keep_in_sight ~dir ?ios_html_scroll_hack elt =
     | _ -> failwith "Ot_sticky.keep_in_sight only supports ~dir:`Top right now."
   in
   let resize_thread = React.S.map compute_top_left Ot_size.height in
-  let onload_thread = Ot_spinner.onloaded |> React.E.map
-    (fun () -> compute_top_left @@ React.S.value Ot_size.height)
+  let onload_thread = Ot_spinner.onloaded |> React.E.map @@
+    fun () -> compute_top_left @@ React.S.value Ot_size.height
   in
-  let stop = Lwt.return @@ fun () ->
-    React.E.stop ~strong:true onload_thread;
-    React.S.stop ~strong:true resize_thread;
-    match glue with | Some g -> dissolve g | None -> ()
+  let stop () =
+    React.E.stop onload_thread;
+    React.S.stop resize_thread;
+    match glue with | Some g -> g.dissolve () | None -> ()
   in
-  Eliom_client.onunload (fun () ->
-    Lwt.async (fun () -> let%lwt stop = stop in stop (); Lwt.return ());
-    None
-  );
-  stop
+  Eliom_client.onunload (fun () -> stop (); None);
+  Lwt.return stop

--- a/src/widgets/ot_sticky.eliomi
+++ b/src/widgets/ot_sticky.eliomi
@@ -26,8 +26,7 @@ type glue = {
   fixed : div_content D.elt;
   inline : div_content D.elt;
   dir : [`Top | `Left];
-  scroll_thread: unit Lwt.t;
-  resize_thread: unit Lwt.t;
+  dissolve : unit -> unit
 }
 
 (** position:sticky polyfill which is not supported by Chrome. It functions by
@@ -43,9 +42,6 @@ val make_sticky :
   ?ios_html_scroll_hack:bool ->
   div_content elt ->
   glue option Lwt.t
-
-(** stop element from being sticky *)
-val dissolve : glue -> unit
 
 (** make sure an element gets never out of sight while scrolling by continuously
     (window scroll/resize) monitoring the position of the element and adjusting


### PR DESCRIPTION
fixes broken sticky tab when page generated on client-side