### PR TITLE
added two operators for more efficient list construction

### DIFF
--- a/src/widgets/ot_pervasives.eliom
+++ b/src/widgets/ot_pervasives.eliom
@@ -1,0 +1,7 @@
+[%%shared.start]
+
+let (@:) x xs = x :: xs
+
+let (@?) x xs = match x with
+  | None -> xs
+  | Some x -> x :: xs

--- a/src/widgets/ot_pervasives.eliomi
+++ b/src/widgets/ot_pervasives.eliomi
@@ -1,0 +1,10 @@
+[%%shared.start]
+
+(** an alias for the operator [::]. [@:] has as opposed to [::] the same
+    operator precedence as [@] which means that these two can be mixed as for
+    instance in the expression [[0] @ 1 @: [2] @ 3 @: [4]] which is also a bit
+    more efficient than [[0] @ [1] @ [2] @ [3] @ [4]]. This operator is supposed
+    to be used as much as possible when creating lists of HTML elements. *)
+val (@:) : 'a -> 'a list -> 'a list
+
+val (@?) : 'a option -> 'a list -> 'a list


### PR DESCRIPTION
Please make sure you agree that this is the right way and place to add these operators.
Refer to: https://github.com/besport/bs/pull/945
Also I wrote this email to start off the discussion:
Building lists, we do it day in day out (cf. the argument of a div) and
we are all annoyed (or should be) by how often we find ourselves writing
the same boilerplate code:

a :: [b,c] @ [d] @ if c then [e] else [] @ [f; g]

So what's wrong with it?
- When adding single elements we use (::) but we can't use it anymore
	after we have added a list, using (@). Compare: "a ::" but "@ [d].
- (@) has linear runtime in the length of its first list. Enough said.

Because of the first point we change the way we write code. We write
functions returning singleton lists, just because otherwise we'd have to
wrap the element at the use site anyway. We use lists instead of the
"option" because its awkwark to convert back and forth between them.

My proposed solution:

let (@:) x xs = x :: xs

This is just an alias for (::), so what good is it? It has the same
precedence as (@), which means we can mix (@:) and (@) as we please:

let mylist = 1 @: [2,3] @ 4 @: [5,6] @ 7 @: []

It is still a bit awkward that the list needs to be terminated with a
"@: []", but oh well... Note that this has still quadratic runtime
(because of the @) but "a bit less so".

In addition I propose this operator to throw elements of type "'a
option" in the mix

let (@?) x xs = match x with
  | None -> xs
  | Some x -> x :: xs

let mylist2 = 1 @: [2,3] @ Some 4 @? [5,6] @ 7 @ []

So henceforth we could give functions which might or might not return a
single element their proper type: option. Note that adding an element
with @? takes also constant time. So, if we adopt this approach, you
should always use the option type instead of a singleton list.