### PR TITLE
ot_carousel.css : removed display attribute for bullet-nav-item class

### DIFF
--- a/css/ot_carousel.css
+++ b/css/ot_carousel.css
@@ -56,7 +56,6 @@
 
 .bullet-nav-item {
 
-    display: inline-block;
     flex: 1 1 0 ;
     cursor: pointer;
     /* width: $carousel-bullet-size ; */


### PR DESCRIPTION
On all the browsers I tried it prevented the bullets to be displayed.