### PR TITLE
ot_carousel bullets function extended

### DIFF
--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -415,7 +415,7 @@ let%shared bullets
     ~(change : ([> `Goto of int | `Next | `Prev ] -> unit) Eliom_client_value.t)
     ~pos ~length
     ?(size = Eliom_shared.React.S.const 1)
-    ?(content = []) () =
+    ?content () =
   let a = (a :> Html_types.ul_attrib attrib list) in
   let bullet i c =
     let class_ = bullet_class i pos size in
@@ -429,20 +429,16 @@ let%shared bullets
            :: a)
       c
   in
-  let rec aux acc i cl =
-    if i = 0
-    then acc
-    else
-      let acc, cl = match cl with
-	| c::cl ->
-	  bullet (i-1) c :: acc, cl
-	| _ ->
-	  bullet (i-1) [] :: acc, []
-      in
-      aux acc (i-1) cl
+  let content = match content with
+    | Some content when List.length content = length ->
+      content
+    | None ->
+      let rec empty l res = if l = 0 then res else f (l-1) ([]::res) in
+      empty length []
+    | _ ->
+      failwith @@ invalid_arg "content"
   in
-  let content = List.rev content in
-  ul ~a:(a_class ["bullet-nav"]::a) (aux [] length content)
+  ul ~a:(a_class ["bullet-nav"]::a) (List.mapi bullet content)
 
 let%shared ribbon
     ?(a = [])

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -433,7 +433,7 @@ let%shared bullets
     | Some content when List.length content = length ->
       content
     | None ->
-      let rec empty l res = if l = 0 then res else f (l-1) ([]::res) in
+      let rec empty l res = if l = 0 then res else empty (l-1) ([]::res) in
       empty length []
     | _ ->
       failwith @@ invalid_arg "content"

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -414,9 +414,10 @@ let%shared bullets
     ?(a = []) ?attributes
     ~(change : ([> `Goto of int | `Next | `Prev ] -> unit) Eliom_client_value.t)
     ~pos ~length
-    ?(size = Eliom_shared.React.S.const 1) () =
+    ?(size = Eliom_shared.React.S.const 1)
+    ?(content = []) () =
   let a = (a :> Html_types.ul_attrib attrib list) in
-  let bullet i =
+  let bullet i c =
     let class_ = bullet_class i pos size in
     let a = match attributes with
       | None -> []
@@ -426,10 +427,22 @@ let%shared bullets
            :: R.a_class class_
            :: a_onclick [%client fun _ -> ~%change (`Goto ~%i)]
            :: a)
-      []
+      c
   in
-  let rec aux acc i = if i = 0 then acc else aux (bullet (i-1)::acc) (i-1) in
-  ul ~a:(a_class ["bullet-nav"]::a) (aux [] length)
+  let rec aux acc i cl =
+    if i = 0
+    then acc
+    else
+      let acc, cl = match cl with
+	| c::cl ->
+	  bullet (i-1) c :: acc, cl
+	| _ ->
+	  bullet (i-1) [] :: acc, []
+      in
+      aux acc (i-1) cl
+  in
+  let content = List.rev content in
+  ul ~a:(a_class ["bullet-nav"]::a) (aux [] length content)
 
 let%shared ribbon
     ?(a = [])

--- a/src/widgets/ot_carousel.eliomi
+++ b/src/widgets/ot_carousel.eliomi
@@ -94,6 +94,8 @@ val make :
     to each bullet (for example a reactive class).
     Optional parameter [size] is the number of elements visible at the same time
     in the carousel (return by function [make]).
+    Optional parameter [content] makes it possible to fill the bullets with Html
+    elements.
  *)
 val bullets :
   ?a:[< Html_types.ul_attrib ] Eliom_content.Html.attrib list ->
@@ -103,6 +105,7 @@ val bullets :
   pos:int Eliom_shared.React.S.t ->
   length:int ->
   ?size:int Eliom_shared.React.S.t ->
+  ?content: [< Html_types.li_content_fun ] Eliom_content.Html.elt list list ->
   unit -> [> `Ul ] Eliom_content.Html.elt
 
 (** Menu (or tabs) for carousel. Current page has class ["active"].


### PR DESCRIPTION
We can now give some Html content to the [bullets] function to fill the generated bullets.