### PR TITLE
Add _opam in gitignore for OPAM 2.0 local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _client
 _deps
 _server
 lib
+_opam


### PR DESCRIPTION
OPAM 2.0 allows to have a local configuration and compiler (see https://opam.ocaml.org/blog/opam-2-0-preview/). This configuration is put in `_opam` directory.
Useful for people who wants to contribute to `ocsigen-toolkit` without having to install all dependencies in another switch.