### PR TITLE
fix: swiping on iOS 10 (on branch bs)

### DIFF
--- a/src/widgets/ot_swipe.eliom
+++ b/src/widgets/ot_swipe.eliom
@@ -56,6 +56,8 @@ let%client dispatch_event ~ev elt name x y =
                val clientY = y
              end)
            in
+           if touch##.target = Js.null then
+             failwith "new Touch() not supported";
            let opt = object%js
              val bubbles = Js._true
              val changedTouches = Js.array [| touch |]


### PR DESCRIPTION
cause: iOS 10 silently doesn't support creation of Touch objects.
solution: when a Touch object is badly created, do fallback to the other solution.

modified:   src/widgets/ot_swipe.eliom