### PR TITLE
Ot_picture_uploader.mk_service becomes server-only

### DIFF
--- a/src/widgets/ot_picture_uploader.eliom
+++ b/src/widgets/ot_picture_uploader.eliom
@@ -397,7 +397,7 @@ let%client bind
       input submit ?cropping ~upload ~after_submit () in
   ()
 
-let%shared mk_service name arg_deriver =
+let%server mk_service name arg_deriver =
   Eliom_service.create_ocaml
     ~name
     ~path:Eliom_service.No_path

--- a/src/widgets/ot_picture_uploader.eliomi
+++ b/src/widgets/ot_picture_uploader.eliomi
@@ -141,10 +141,6 @@ val submit :
   -> [< Html_types.button_content ] Eliom_content.Html.elt list
   -> [> `Button ] Eliom_content.Html.elt
 
-(** [mk_service name arg_deriver]
-    Create a named service taking [(arg_deriver, (cropping, file))] parameter *)
-val mk_service : string -> 'a Deriving_Json.t -> ('a,'b) service
-
 (** Ready-to-use form. Customizable with
     [input], the input button content, [submit], the submit button content.
     If [crop] is present, cropping is enable, with the optional ratio it is.
@@ -159,3 +155,9 @@ val mk_form :
               * [< Html_types.button_content_fun ] Eliom_content.Html.elt list)
   -> 'a upload
   -> [> `Form ] Eliom_content.Html.elt Lwt.t
+
+[%%server.start]
+
+(** [mk_service name arg_deriver] Create a named service taking
+    [(arg_deriver, (cropping, file))] parameter *)
+val mk_service : string -> 'a Deriving_Json.t -> ('a,'b) service


### PR DESCRIPTION
We are planning to remove the client-side service creation API from Eliom. This will enforce using injections for services, and thus lead to a less error-prone programming style.

There is already an Eliom branch for that (`service-server-only`).

The first step is to remove client-side service creation from the reverse dependencies of Eliom. It will be smoother if we merge the associated PRs before the upcoming Eliom one.