### PR TITLE
Carousel performance improvements

### DIFF
--- a/css/ot_carousel.css
+++ b/css/ot_carousel.css
@@ -135,7 +135,8 @@
     height: 3px;
     bottom: 0;
     background-color: #66aaff;
-    transition-property: left, right;
+    transition-property: transform, width;
+    will-change: transform, width;
 }
 
 .ot-carousel.ot-full-height > .ot-car2:not(.ot-swiping)

--- a/css/ot_carousel.css
+++ b/css/ot_carousel.css
@@ -19,6 +19,7 @@
     height: 100%;
     width: 100%;
 }
+.ot-carousel > .ot-car2.ot-swiping { will-change: transform; }
 
 .ot-carousel > .ot-car2 .ot-carpage {
         width: 100% ;

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -120,7 +120,13 @@ let%shared make
   (* We wrap all pages in a div in order to add class carpage,
      for efficiency reasons in CSS (avoids selector ".ot-car2>*")*)
   let pages = List.mapi (fun i e ->
-    D.div ~a:( a_class ["ot-carpage"]
+    let clss =
+      if i >= position && i < position + 1 then
+        ["ot-carpage"; "ot-active"]
+      else
+        ["ot-carpage"]
+    in
+    D.div ~a:( a_class clss
                :: Eliom_shared.Value.local make_page_attribute ~vertical i)
                             [e]) l
   in

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -757,44 +757,44 @@ let%shared ribbon
                  | Some firstselectedelt, Some lastselectedelt ->
                    let firstselectedelt = To_dom.of_element firstselectedelt in
                    let lastselectedelt = To_dom.of_element lastselectedelt in
-                   let left = firstselectedelt##.offsetLeft + curleft in
-                   let right =
-                     - lastselectedelt##.offsetLeft
-                     - lastselectedelt##.offsetWidth
-                     + the_ul'##.offsetWidth
-                     - curleft
-                   in
                    let offset_left =
                      if offset >= 0.
-                     then int_of_float
+                     then
                          (offset *. float firstselectedelt##.offsetWidth)
                      else
                        match previouselt with
-                       | None -> 0
+                       | None -> 0.
                        | Some elt ->
-                         int_of_float
                            (offset
                             *. float (To_dom.of_element elt)##.offsetWidth)
                    in
                    let offset_right =
                      if offset <= 0.
                      then
-                       int_of_float
                          (offset *. float lastselectedelt##.offsetWidth)
                      else
                        match nextelt with
-                       | None -> 0
+                       | None -> 0.
                        | Some elt ->
-                         int_of_float
                            (offset
                             *. float (To_dom.of_element elt)##.offsetWidth)
                    in
-                   let left =
-                     Js.string (string_of_int (left + offset_left) ^ "px") in
-                   let right =
-                     Js.string (string_of_int (right - offset_right) ^ "px") in
-                   (To_dom.of_element cursor_elt)##.style##.left := left;
-                   (To_dom.of_element cursor_elt)##.style##.right := right
+                   let left = firstselectedelt##.offsetLeft + curleft in
+                   let width =
+                     lastselectedelt##.offsetLeft
+                     + lastselectedelt##.offsetWidth
+                     - firstselectedelt##.offsetLeft
+                     + truncate (offset_right -. offset_left +. 0.5) in
+                   let transform =
+                     Js.string
+                       (Printf.sprintf "translateX(%dpx)"
+                          (left + truncate (offset_left +. 0.5)))
+                   in
+                   let width = Js.string (string_of_int width ^ "px") in
+                   let style = (To_dom.of_element cursor_elt)##.style in
+                   (Js.Unsafe.coerce style)##.transform := transform;
+                   (Js.Unsafe.coerce style)##.webkitTransform := transform;
+                   style##.width := width
                  | _ -> ()
               )
               ~%pos


### PR DESCRIPTION
Add `will-change` hints and use `transform` to translate the cursor.

We now assume that the cursor has no margin, so some style adjustments may be needed for drawing the cursor.