### PR TITLE
use ##.style instead of getComputedStyle

### DIFF
--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -7,7 +7,7 @@ open Html_types
 
 let is_position_sticky elt =
   let pos = Js.to_string
-      (Dom_html.window##getComputedStyle (To_dom.of_element elt))##.position
+      (To_dom.of_element elt)##.style##.position
   in pos = "-webkit-sticky" || pos = "sticky"
 
 let set_position_sticky elt =

--- a/src/widgets/ot_sticky.eliom
+++ b/src/widgets/ot_sticky.eliom
@@ -7,8 +7,11 @@ open Html_types
 
 let is_position_sticky elt =
   let pos = Js.to_string
+      (Dom_html.window##getComputedStyle (To_dom.of_element elt))##.position
+  in pos = "-webkit-sticky" || pos = "sticky" ||
+  (let pos = Js.to_string
       (To_dom.of_element elt)##.style##.position
-  in pos = "-webkit-sticky" || pos = "sticky"
+  in pos = "-webkit-sticky" || pos = "sticky")
 
 let set_position_sticky elt =
   is_position_sticky elt || begin


### PR DESCRIPTION
because for some unknown reasons, the getComputedStyle way doesn't work on iOS 10's Webkit