### PR TITLE
Ot_nodeready: do not watch elements forever, to avoid memory leaks

### DIFF
--- a/src/widgets/ot_nodeready.eliom
+++ b/src/widgets/ot_nodeready.eliom
@@ -24,7 +24,29 @@ let rec node_in_document node =
   node == (Dom_html.document :> Dom.node Js.t) ||
   Js.Opt.case (node##.parentNode) (fun () -> false) node_in_document
 
+let age = ref 0
 let watched = ref []
+
+(* We remove watched elements after two unload events to avoid memory
+   leaks due to elements that are never inserted in the page. *)
+let active = ref false
+let remove_from_dead_pages () =
+  let rec loop () =
+    Eliom_client.onunload @@ fun () ->
+    let (live, dead) =
+      List.partition (fun (age', _, _) -> !age = age') !watched in
+    watched := live;
+    incr age;
+    List.iter (fun (_, _, s) -> Lwt.wakeup s ()) dead;
+    if !watched = [] then
+      active := false
+    else
+      loop ()
+  in
+  if not !active then begin
+    active := true;
+    loop ()
+  end
 
 let handler records observer =
   let changes = ref false in
@@ -34,10 +56,10 @@ let handler records observer =
   done;
   if !changes then begin
     let (ready, not_ready) =
-      List.partition (fun (n, _) -> node_in_document n) !watched in
+      List.partition (fun (_, n, _) -> node_in_document n) !watched in
     watched := not_ready;
     if not_ready = [] then observer##disconnect;
-    List.iter (fun (_, s) -> Lwt.wakeup s ()) ready
+    List.iter (fun (_, _, s) -> Lwt.wakeup s ()) ready
   end
 
 let observer =
@@ -54,6 +76,7 @@ let nodeready node =
   if node_in_document node then Lwt.return_unit else begin
     let t, s = Lwt.wait () in
     if !watched = [] then observer##observe Dom_html.document config;
-    watched := (node, s) :: !watched;
+    watched := (!age, node, s) :: !watched;
+    remove_from_dead_pages ();
     t
   end


### PR DESCRIPTION
We stop watching an element after two page changes.