### PR TITLE
Ot_drawer: compatibility with DOM caching

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-toolkit"
-version: "2.0.dev"
+version: "2.0.dev2"
 maintainer: "dev@ocsigen.org"
 synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
 description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."

--- a/src/widgets/ot_calendar.eliom
+++ b/src/widgets/ot_calendar.eliom
@@ -21,6 +21,7 @@
 [%%shared.start] (* shared by default, override as necessary *)
 
 open Eliom_content.Html
+open Js_of_ocaml
 
 module A = CalendarLib.Date
 
@@ -155,16 +156,16 @@ let rec build_calendar
   and zero = zeroth_displayed_day ~intl day
   and prev_button =
     D.(span ~a:[a_class ["ot-c-prev-button"]]
-         [pcdata b_prev_month])
+         [txt b_prev_month])
   and next_button =
     D.(span ~a:[a_class ["ot-c-next-button"]]
-         [pcdata b_next_month])
+         [txt b_next_month])
   and prev_year_button =
     D.(span ~a:[a_class ["ot-c-prev-year-button"]]
-         [pcdata b_prev_year])
+         [txt b_prev_year])
   and next_year_button =
     D.(span ~a:[a_class ["ot-c-next-year-button"]]
-         [pcdata b_next_year])
+         [txt b_next_year])
   in
   let thead =
     D.(thead
@@ -172,11 +173,11 @@ let rec build_calendar
                 [prev_year_button;
                  prev_button;
                  CalendarLib.Printer.Date.sprint "%B %Y" fst_dow |>
-                 pcdata;
+                 txt;
                  next_button;
                  next_year_button]];
           tr (List.map
-                (fun d -> th [pcdata d])
+                (fun d -> th [txt d])
                 (get_rotated_days intl))])
   and f_cell i j =
     let d =
@@ -202,7 +203,7 @@ let rec build_calendar
            classes
        in
        [D.a_class classes],
-       [D.div [A.day_of_month d |> string_of_int |> D.pcdata]])
+       [D.div [A.day_of_month d |> string_of_int |> D.txt]])
     else
       [], []
   and f_a_row i = [] in

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -38,10 +38,9 @@ TODO:
 *)
 
 
-[%%shared
-open Eliom_content.Html
-open Eliom_content.Html.F
-]
+open%shared Js_of_ocaml
+open%shared Eliom_content.Html
+open%shared Eliom_content.Html.F
 
 let%client clX = Ot_swipe.clX
 
@@ -513,7 +512,7 @@ let%shared generate_content generator =
   with e ->
     Lwt.return @@
     if Eliom_config.get_debugmode ()
-    then em [ pcdata (Printexc.to_string e) ]
+    then em [ txt (Printexc.to_string e) ]
     else begin
       let e = Printexc.to_string e in
       ignore [%client (Firebug.console##error
@@ -526,9 +525,9 @@ let%shared generate_content generator =
 let%shared default_fail e =
   [
     if Eliom_config.get_debugmode ()
-    then em [ pcdata (Printexc.to_string e) ]
+    then em [ txt (Printexc.to_string e) ]
     else em ~a:[ a_class ["ot-icon-question"] ]
-        [ pcdata (Printexc.to_string e) ] ]
+        [ txt (Printexc.to_string e) ] ]
 
 (* on the client side we generate the contents of the initially visible page
    asynchronously so the tabs will be rendered right away *)
@@ -909,13 +908,13 @@ let%shared next ?(a = [])
 (*       ~button_type:`Button *)
 (*       ~a:[a_class ["ot-car-prev"]; *)
 (*           a_onclick {{ fun _ -> %change `Prev }}] *)
-(*       [pcdata ([%i18n prev_col ())] *)
+(*       [txt ([%i18n prev_col ())] *)
 (*   in *)
 (*   let next = button *)
 (*       ~button_type:`Button *)
 (*       ~a:[a_class ["ot-car-next"]; *)
 (*           a_onclick {{ fun _ -> %change `Next }}] *)
-(*       [pcdata ([%i18n next_col ())] *)
+(*       [txt ([%i18n next_col ())] *)
 (*   in *)
 (*   D.div ~a:(a_class ["ot-car-nav"]::a) [prev; menu; next] *)
 
@@ -1036,10 +1035,10 @@ let%shared wheel
 (*        let d, _ = make *)
 (*            ~position:2 *)
 (*            ~update:ev *)
-(*            [div [h1 [pcdata "Coucou 1"]]; *)
-(*             div [h1 [pcdata "Bonjour 2"]]; *)
-(*             div [h1 [pcdata "Salut 3"]]; *)
-(*             div [h1 [pcdata "Hello 4"]]; *)
+(*            [div [h1 [txt "Coucou 1"]]; *)
+(*             div [h1 [txt "Bonjour 2"]]; *)
+(*             div [h1 [txt "Salut 3"]]; *)
+(*             div [h1 [txt "Hello 4"]]; *)
 (*            ] *)
 (*        in *)
 (*        Manip.appendToBody d; *)

--- a/src/widgets/ot_carousel.eliomi
+++ b/src/widgets/ot_carousel.eliomi
@@ -21,6 +21,8 @@
 
 [%%shared.start]
 
+open Js_of_ocaml
+
 (** {2 Carousel}
 
     This is a widget containing blocks. One or several blocks are

--- a/src/widgets/ot_form.eliom
+++ b/src/widgets/ot_form.eliom
@@ -18,6 +18,7 @@
 
 [%%client.start]
 
+open Js_of_ocaml
 open Eliom_content.Html
 open Eliom_content.Html.F
 

--- a/src/widgets/ot_form.eliomi
+++ b/src/widgets/ot_form.eliomi
@@ -18,6 +18,7 @@
 
 [%%client.start]
 
+open Js_of_ocaml
 open Eliom_content.Html
 open Html_types
 

--- a/src/widgets/ot_lib.eliomi
+++ b/src/widgets/ot_lib.eliomi
@@ -21,6 +21,8 @@
 
 [%%client.start]
 
+open Js_of_ocaml
+
 val in_ancestors : elt:Dom_html.element Js.t -> ancestor:Dom_html.element Js.t -> bool
 
 val onloads : (unit -> unit) -> unit

--- a/src/widgets/ot_nodeready.eliomi
+++ b/src/widgets/ot_nodeready.eliomi
@@ -20,6 +20,8 @@
 
 [%%client.start]
 
+open Js_of_ocaml
+
 (** Wait for a node to be inserted in the DOM.
 
     {3 Example}

--- a/src/widgets/ot_noderesize.eliom
+++ b/src/widgets/ot_noderesize.eliom
@@ -18,8 +18,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
-[%%client open Eliom_content.Html ]
-[%%client open Eliom_content.Html.F ]
+open%client Js_of_ocaml
+open%client Eliom_content.Html
+open%client Eliom_content.Html.F
 
 [%%client type resize_sensor =
             { watched : Dom_html.element Js.t

--- a/src/widgets/ot_noderesize.eliomi
+++ b/src/widgets/ot_noderesize.eliomi
@@ -25,6 +25,8 @@
 
 [%%client.start]
 
+open Js_of_ocaml
+
 (** {2 Get an event when an element's size changes}
 
     {3 Known issues}

--- a/src/widgets/ot_page_transition.eliom
+++ b/src/widgets/ot_page_transition.eliom
@@ -1,4 +1,5 @@
 [%%client.start]
+open Js_of_ocaml
 open Eliom_content
 open Html
 open Html.D

--- a/src/widgets/ot_picture_uploader.eliom
+++ b/src/widgets/ot_picture_uploader.eliom
@@ -18,8 +18,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
-[%%shared open Eliom_content.Html ]
-[%%shared open Eliom_content.Html.F ]
+open%shared Js_of_ocaml
+open%shared Eliom_content.Html
+open%shared Eliom_content.Html.F
 
 [%%shared
 type ('a,'b) service =

--- a/src/widgets/ot_picture_uploader.eliomi
+++ b/src/widgets/ot_picture_uploader.eliomi
@@ -20,6 +20,8 @@
 
 [%%shared.start]
 
+open Js_of_ocaml
+
 (** {2 Picture uploader widget}
 
     [Ot_picture_uploader] allows the user to see a picture he wants to

--- a/src/widgets/ot_range.eliom
+++ b/src/widgets/ot_range.eliom
@@ -21,8 +21,8 @@
 [%%shared.start] (* shared by default, override as necessary *)
 
 open Eliom_content.Html
-
 open Eliom_shared.React.S.Infix
+open Js_of_ocaml
 
 let display_aux (_, _, a) v =
   let v =
@@ -32,7 +32,7 @@ let display_aux (_, _, a) v =
     | None ->
       string_of_int v
   and a = [D.a_class ["ot-r-value"]] in
-  D.div ~a [D.pcdata v]
+  D.div ~a [D.txt v]
 
 let%client go_up (lb, ub, a) r (f : ?step:_ -> _) =
   let v = Eliom_shared.React.S.value r in
@@ -55,12 +55,12 @@ let display
        [div ~a:[a_class ["ot-r-up"];
                 a_onclick
                   [%client (fun _ -> go_up ~%e ~%v ~%f : _ -> _) ]]
-          [pcdata txt_up];
+          [txt txt_up];
         display_aux e v;
         div ~a:[a_class ["ot-r-down"];
                 a_onclick
                   [%client (fun _ -> go_down ~%e ~%v ~%f : _ -> _) ]]
-          [pcdata txt_down]])
+          [txt txt_down]])
 
 let make ?txt_up ?txt_down ?f ?lb:(lb = 0) ub =
   assert (ub > lb);

--- a/src/widgets/ot_size.eliom
+++ b/src/widgets/ot_size.eliom
@@ -21,6 +21,10 @@
 
 
 [%%client.start]
+
+open Js_of_ocaml
+
+
 (* size and orientation *)
 type orientation = Portrait | Landscape
 

--- a/src/widgets/ot_size.eliomi
+++ b/src/widgets/ot_size.eliomi
@@ -22,6 +22,8 @@
 
 [%%client.start]
 
+open Js_of_ocaml
+
 (** {2 Size functions for Dom elements}
 
     {3 Size and orientation} *)

--- a/src/widgets/ot_spinner.eliom
+++ b/src/widgets/ot_spinner.eliom
@@ -19,14 +19,15 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-[%%shared open Eliom_content.Html ]
-[%%shared open Eliom_content.Html.F ]
-[%%client open Eliom_shared ]
+open%shared Js_of_ocaml
+open%shared Eliom_content.Html
+open%shared Eliom_content.Html.F
+open%client Eliom_shared
 
 let%shared default_fail_fun e =
   [
     if Eliom_config.get_debugmode ()
-    then em [ pcdata (Printexc.to_string e) ]
+    then em [ txt (Printexc.to_string e) ]
     else begin
       let e = Printexc.to_string e in
       ignore [%client (Firebug.console##error

--- a/src/widgets/ot_style.eliom
+++ b/src/widgets/ot_style.eliom
@@ -16,7 +16,8 @@ val parse_px : Js.js_string Js.t -> float option
 *)
 
 [%%client.start]
-
+ 
+open Js_of_ocaml
 open Eliom_content.Html
 
 let parse_px str =

--- a/src/widgets/ot_style.eliomi
+++ b/src/widgets/ot_style.eliomi
@@ -2,6 +2,7 @@
 
 (** This module is an interface to getComputedStyle. *)
 
+open Js_of_ocaml
 open Eliom_content.Html
 
 val parse_px : Js.js_string Js.t -> float option

--- a/src/widgets/ot_swipe.eliom
+++ b/src/widgets/ot_swipe.eliom
@@ -1,7 +1,8 @@
 (** Swiping an element *)
 
-[%%shared open Eliom_content.Html ]
-[%%shared open Eliom_content.Html.F ]
+open%shared Js_of_ocaml
+open%shared Eliom_content.Html
+open%shared Eliom_content.Html.F
 
 (** sensibility for detecting swipe left/right or up/down *)
 let%client threshold = 0

--- a/src/widgets/ot_swipe.eliomi
+++ b/src/widgets/ot_swipe.eliomi
@@ -1,5 +1,7 @@
 [%%shared.start]
 
+open Js_of_ocaml
+
 (**
    [bind ~compute_final_pos elt] makes [elt] left-right
    swipable on touch screens.

--- a/src/widgets/ot_time_picker.eliom
+++ b/src/widgets/ot_time_picker.eliom
@@ -21,8 +21,8 @@
 [%%shared.start] (* shared by default, override as necessary *)
 
 open Eliom_shared.React.S.Infix
-
 open Eliom_content.Html
+open Js_of_ocaml
 
 type polar = int * int
 
@@ -202,7 +202,7 @@ let clock_reactive_hand_circle
       R.a_cy cy
     ]
   in
-  Eliom_content.Svg.(D.circle ~a [D.title (D.pcdata "")])
+  Eliom_content.Svg.(D.circle ~a [D.title (D.txt "")])
 
 let make_clock_point
     ?zero_is_12:(zero_is_12 = false)
@@ -216,13 +216,13 @@ let make_clock_point
     :: a_x_list [float_of_int x, Some `Px]
     :: a_y_list [float_of_int y, Some `Px]
     :: extra_attributes
-  and txt =
+  and msg =
     if i = 0 && zero_is_12 then
       "12"
     else
       string_of_int (step * i)
   in
-  text ~a [pcdata txt]
+  text ~a [txt msg]
 
 let clock_svg
     ?zero_is_12
@@ -411,7 +411,7 @@ let display_hours_minutes_seq ?h24:(h24 = false) f (h, m) b =
       else
         [D.a_class ["ot-tp-hours"; "ot-tp-inactive"];
          D.a_onclick [%client  fun _ -> ~%f true ]]
-    and c = [string_of_hours ~h24 h |> D.pcdata] in
+    and c = [string_of_hours ~h24 h |> D.txt] in
     D.span ~a c
   and m =
     let a =
@@ -420,14 +420,14 @@ let display_hours_minutes_seq ?h24:(h24 = false) f (h, m) b =
            a_onclick [%client  fun _ -> ~%f false ]]
       else
         [D.a_class ["ot-tp-minutes"; "ot-tp-active"]]
-    and c = [Printf.sprintf "%02d" m |> D.pcdata] in
+    and c = [Printf.sprintf "%02d" m |> D.txt] in
     D.span ~a c
   and a = [D.a_class ["ot-tp-display"]] in
   if h24 then
-    D.div ~a [h'; D.pcdata ":"; m]
+    D.div ~a [h'; D.txt ":"; m]
   else
-    D.div ~a [h'; D.pcdata ":"; m;
-              D.pcdata (if h < 12 then " AM" else " PM")]
+    D.div ~a [h'; D.txt ":"; m;
+              D.txt (if h < 12 then " AM" else " PM")]
 
 let combine_inputs_hours_minutes ?round_5 e_h e_m z_e_h z_e_m is_am =
   let f = [%shared fun (x, b) -> if b then Some x else None ] in

--- a/src/widgets/ot_tip.eliom
+++ b/src/widgets/ot_tip.eliom
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+open%client Js_of_ocaml
 open%client Eliom_content.Html
 open%client Eliom_content.Html.F
 

--- a/src/widgets/ot_tip.eliomi
+++ b/src/widgets/ot_tip.eliomi
@@ -21,6 +21,8 @@
 
 [%%client.start]
 
+open Js_of_ocaml
+
 (** {2 Tip widget} *)
 
 (** This module implement a [display] function which actually display a tip

--- a/src/widgets/ot_toggle.eliom
+++ b/src/widgets/ot_toggle.eliom
@@ -21,8 +21,8 @@
 [%%shared.start] (* shared by default, override as necessary *)
 
 open Eliom_content.Html
-
 open Eliom_shared.React.S.Infix
+open Js_of_ocaml
 
 type t = T_Up | T_Down
 
@@ -37,17 +37,17 @@ let display_toggle
   | T_Up ->
     div ~a:[a_class ["ot-toggle"]]
       [div ~a:[a_class ["ot-active"; "ot-up"]]
-         [pcdata up_txt];
+         [txt up_txt];
        div ~a:[a_class ["ot-inactive"; "ot-down"];
                a_onclick [%client (fun _ -> ~%f T_Down : _ -> _) ]]
-         [pcdata down_txt]]
+         [txt down_txt]]
   | T_Down ->
     div ~a:[a_class ["ot-toggle"]]
       [div ~a:[a_class ["ot-inactive"; "ot-up"];
                a_onclick [%client (fun _ -> ~%f T_Up : _ -> _) ]]
-         [pcdata up_txt];
+         [txt up_txt];
        div ~a:[a_class ["ot-active"; "ot-down"]]
-         [pcdata down_txt]]
+         [txt down_txt]]
 
 let make
       ?init_up:(init_up = false) ?up_txt ?down_txt


### PR DESCRIPTION
reinstate "ot-drawer-open" on html element when returning to page