### PR TITLE
fix : add a rule to put ot_color_picker.css into share folder

### DIFF
--- a/ocsigen-toolkit.install
+++ b/ocsigen-toolkit.install
@@ -9,4 +9,5 @@ share: [
   "css/ot_buttons.css"          {"css/ot_buttons.css"}
   "css/ot_sticky.css"           {"css/ot_sticky.css"}
   "css/ot_page_transition.css"  {"css/ot_page_transition.css"}
+  "css/ot_color_picker.css"     {"css/ot_color_picker.css"}
 ]


### PR DESCRIPTION
Make that ot_color_picker.css is put into the folder .opam/<version>/share/ocsigen-toolkit/css when ocsigen-toolkit is installed by opam.