### PR TITLE
[pulltorefresh] don't lose wrapper attributes on browser

### DIFF
--- a/src/widgets/ot_pulltorefresh.eliom
+++ b/src/widgets/ot_pulltorefresh.eliom
@@ -159,7 +159,7 @@ let make ?(a = []) ?(app_only = true) ?(scale = 5.) ?(dragThreshold = 80.)
     (afterPull : (unit -> bool Lwt.t) Eliom_client_value.t)
   =
   if app_only && not (Eliom_client.is_client_app ())
-  then content
+  then div ~a [content]
   else
     let state_s, set_state = Eliom_shared.React.S.create None in
     let headContainer =


### PR DESCRIPTION
The last PR introduced an option to make the wrapping happen only on mobile apps.
In this case, the browser version lost the given attributes (`~a`)

We want to keep those.