### PR TITLE
Toggle popups scroll hack parameter

### DIFF
--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -33,6 +33,7 @@ let%shared hcf ?(a=[]) ?(header=[]) ?(footer=[]) content =
 
 let%client popup
     ?(a = [])
+    ?(enable_scrolling_hack=true)
     ?close_button
     ?confirmation_onclose
     ?(onclose = fun () -> Lwt.return_unit)
@@ -63,15 +64,18 @@ let%client popup
   let scroll_pos = ref (Js.Unsafe.coerce Dom_html.window)##.pageYOffset in
   let stop, stop_thread = React.E.create () in
   Eliom_client.Page_status.onactive ~stop (fun () ->
-    html_ManipClass_add "ot-with-popup";
-    Dom_html.document##.body##.style##.top :=
-      Js.string (Printf.sprintf "%dpx" (- !scroll_pos))
+    if enable_scrolling_hack then (
+      html_ManipClass_add "ot-with-popup";
+      Dom_html.document##.body##.style##.top :=
+        Js.string (Printf.sprintf "%dpx" (- !scroll_pos)))
   );
 
   let reset () =
-    html_ManipClass_remove "ot-with-popup";
-    Dom_html.document##.body##.style##.top := Js.string "";
-    Dom_html.window##scroll 0 !scroll_pos
+    if enable_scrolling_hack then (
+      html_ManipClass_remove "ot-with-popup";
+      Dom_html.document##.body##.style##.top := Js.string "";
+      Dom_html.window##scroll 0 !scroll_pos
+    )
   in
 
   let do_close () =

--- a/src/widgets/ot_popup.eliomi
+++ b/src/widgets/ot_popup.eliomi
@@ -56,8 +56,6 @@ val hcf :
     [gen_content] is a function taking the function closing the popup as
     parameter, and returning the popup content.
 
-    For [ios_scroll_pos_fix] see [Ot_drawer.drawer].
-
     If [close_on_background_click] (default: false) is true then clicking on the
     background of the popup closes it.
 

--- a/src/widgets/ot_popup.eliomi
+++ b/src/widgets/ot_popup.eliomi
@@ -40,9 +40,13 @@ val hcf :
 
 [%%client.start]
 
-(** [ popup ?a ?close_button ?confirmation_onclose ?onclose gen_content ]
+(** [ popup ?a ?enable_scrolling_hack
+       ?close_button ?confirmation_onclose ?onclose gen_content ]
     Display a modal popup.
     Returns the popup container, in case you need it.
+
+    [enable_scrolling_hack] (default: [true]) toggle the hack setting
+    popup background (body) to [fixed] when popups open
 
     Use [close_button] if you want to add a button to close the popup.
 
@@ -64,6 +68,7 @@ val hcf :
 *)
 val popup :
   ?a:[< div_attrib ] attrib list
+  -> ?enable_scrolling_hack:bool
   -> ?close_button:(button_content elt list)
   -> ?confirmation_onclose:(unit -> bool Lwt.t)
   -> ?onclose:(unit -> unit Lwt.t)


### PR DESCRIPTION
This parameter exist to be able to disable scroll hacks on popups.
This is useful to have full control on what happens when any popup is closed.