### PR TITLE
[ot-calendar] Remodelling of the calendar toolkit

### DIFF
--- a/css/ot_datetime.css
+++ b/css/ot_datetime.css
@@ -124,6 +124,30 @@ div.ot-tp-container div.ot-tp-display {
     padding: 6px;
     font-size: 22px;
 }
+.ot-c-pv-nx-button, .ot-c-pv-nx-select {
+    display: inline;
+    padding: 17px;
+}
+div.ot-c-pv-nx-button span, div.ot-c-pv-nx-select select {
+    padding: 10px;
+}
+.ot-c-select-month, .ot-c-select-year {
+    border: 0px;
+    outline: 0px;
+    width: 60px; 
+    text-align-last:center;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='-5 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-position: right 0px center;
+    background-repeat: no-repeat;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    font-weight: bold;
+}
+.ot-c-out-period {
+    background-color: #fcfcfc;
+    color: rgb(200, 200, 200);
+    pointer-events: none;
+}
 .ot-c-table {
     font-size: 14px;
     line-height: 22px;

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-toolkit"
-version: "2.10.1"
+version: "2.11.0"
 maintainer: "dev@ocsigen.org"
 synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
 description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."

--- a/src/widgets/ot_calendar.eliom
+++ b/src/widgets/ot_calendar.eliom
@@ -47,9 +47,10 @@ let default_intl =
       ; "Dec" ]
   ; i_start = `Sun }
 
-type period = {start : int; limit : int}
+type 'a period = {begin_p : 'a A.date; end_p : 'a A.date}
 
-let default_period = {start = 1; limit = 3200}
+let default_period =
+  {begin_p = A.lmake ~year:1 (); end_p = A.lmake ~year:3200 ~month:12 ~day:31 ()}
 
 type button_labels =
   { b_prev_year : string
@@ -198,7 +199,7 @@ let zeroth_displayed_day ~intl d =
 
 let rec build_calendar ?prehilight
     ~button_labels:{b_prev_year; b_prev_month; b_next_month; b_next_year} ~intl
-    day
+    ~period day
   =
   let today = A.today () in
   let fst_dow = fst_dow ~intl day
@@ -225,9 +226,9 @@ let rec build_calendar ?prehilight
     select
       ~a:[a_name "ot-c-select-year"]
       (List.init
-         (default_period.limit - default_period.start + 1)
+         A.(year period.end_p - year period.begin_p + 1)
          (fun i ->
-           let y = string_of_int (default_period.limit - i) in
+           let y = string_of_int (A.year period.end_p - i) in
            if year = y
            then option ~a:[a_value y; a_selected ()] (txt y)
            else option ~a:[a_value y] (txt y)))
@@ -252,7 +253,9 @@ let rec build_calendar ?prehilight
       let module C = CalendarLib.Calendar in
       let today = A.today () in
       let classes =
-        [ (if d < today
+        [ (if d < period.begin_p || d > period.end_p
+          then "ot-c-out-period"
+          else if d < today
           then "ot-c-past"
           else if d = today
           then "ot-c-today"
@@ -307,8 +310,19 @@ let%client update_classes cal zero d =
   in
   iter_interval 0 5 f
 
+let%client in_period ?(begin_p = default_period.begin_p)
+    ?(end_p = default_period.end_p) curr_date
+  =
+  curr_date >= begin_p && curr_date <= end_p
+
+let%client in_period_coerced ?(begin_p = default_period.begin_p)
+    ?(end_p = default_period.end_p) curr_date
+  =
+  curr_date >= (begin_p :> [`Month | `Year] A.date)
+  && curr_date <= (end_p :> [`Month | `Year] A.date)
+
 let%client attach_events ?action ?(click_non_highlighted = false) ?update ~intl
-    d cal highlight
+    ~period d cal highlight
   =
   let rows = (To_dom.of_table cal)##.rows in
   let fst_dow = fst_dow ~intl d and zero = zeroth_displayed_day ~intl d in
@@ -334,8 +348,11 @@ let%client attach_events ?action ?(click_non_highlighted = false) ?update ~intl
       | None -> fun _ r -> update_classes cal zero d; Lwt.return_unit
     in
     let set_onclick () =
-      let f () = Lwt_js_events.clicks c action in
-      Lwt.async f
+      if in_period d ~begin_p:period.begin_p ~end_p:period.end_p
+      then
+        let f () = Lwt_js_events.clicks c action in
+        Lwt.async f
+      else Lwt.async (fun () -> Lwt.return_unit)
     in
     if List.exists (( = ) dom) highlight
     then (
@@ -345,26 +362,29 @@ let%client attach_events ?action ?(click_non_highlighted = false) ?update ~intl
     then set_onclick ()
     else ()
 
-let%client attach_events_lwt ?action ?click_non_highlighted ~intl d cal
+let%client attach_events_lwt ?action ?click_non_highlighted ~intl ~period d cal
     highlight
   =
   let f () =
     let m = A.(month d |> int_of_month) and y = A.year d in
     let%lwt highlight = highlight y m in
-    attach_events ?action ?click_non_highlighted ~intl d cal highlight;
+    attach_events ?action ?click_non_highlighted ~intl ~period d cal highlight;
     Lwt.return_unit
   in
   Lwt.async f
 
 let%client make_span_handler selector
     ((get_sig, set_sig) : int React.signal * (?step:React.step -> int -> unit))
-    apply fun_handler
+    apply condi fun_handler
   =
   Dom_html.handler (fun _ ->
-      fun_handler ();
-      set_sig (apply (React.S.value get_sig) 1);
-      selector##.selectedIndex := React.S.value get_sig;
-      Js._false)
+      if condi ()
+      then (
+        fun_handler ();
+        set_sig (apply (React.S.value get_sig) 1);
+        selector##.selectedIndex := React.S.value get_sig;
+        Js._false)
+      else Js._false)
 
 let%client set_selected_index selector selector_value options
     ((get_sig, set_sig) : int React.signal * (?step:React.step -> int -> unit))
@@ -377,57 +397,82 @@ let%client set_selected_index selector selector_value options
     selector##.selectedIndex := React.S.value get_sig
   with Not_found -> ()
 
-let%client make_selector_handler change_index fun_handler =
-  Dom_html.handler (fun _ -> fun_handler (); change_index (); Js._false)
+let%client make_selector_handler change_index condi fun_handler =
+  Dom_html.handler (fun _ ->
+      if condi ()
+      then (fun_handler (); change_index (); Js._false)
+      else Js._false)
 
-let%client attach_behavior ?highlight ?click_non_highlighted ?action ~intl d
-    (cal, prev, next, select_month, select_year, prev_year, next_year) f_d
+let%client attach_behavior ?highlight ?click_non_highlighted ?action ~intl
+    ~period d (cal, prev, next, select_month, select_year, prev_year, next_year)
+    f_d
   =
   (match highlight with
   | Some highlight ->
-      attach_events_lwt ?click_non_highlighted ?action ~intl d cal highlight
-  | None -> attach_events ?click_non_highlighted ?action ~intl d cal []);
+      attach_events_lwt ?click_non_highlighted ?action ~intl ~period d cal
+        highlight
+  | None -> attach_events ?click_non_highlighted ?action ~intl ~period d cal []);
   let s_y = To_dom.of_select select_year in
   let s_m = To_dom.of_select select_month in
   let s_y_v () = Js.to_string s_y##.value in
   let s_m_v () = Js.to_string s_m##.value in
   let options_year = get_options s_y in
   let options_month = get_options s_m in
+  let valid_period condi () =
+    in_period_coerced ~begin_p:period.begin_p ~end_p:period.end_p condi
+  in
+  let select_condi =
+    valid_period
+      (A.make_year_month
+         (s_y_v () |> int_of_string)
+         (s_m_v () |> int_of_strmonth))
+  in
   let select_handler () =
     f_d
       (A.make_year_month
          (s_y_v () |> int_of_string)
          (s_m_v () |> int_of_strmonth))
   in
-  let sig_year = React.S.create (default_period.limit - A.year d) in
+  let sig_year = React.S.create (A.year period.end_p - A.year d) in
   let sig_month = React.S.create ((A.month d |> int_of_month) - 1) in
   s_y##.selectedIndex := React.S.value (fst sig_year);
   s_m##.selectedIndex := React.S.value (fst sig_month);
   s_y##.onchange :=
     make_selector_handler
       (set_selected_index s_y s_y_v options_year sig_year)
-      select_handler;
+      select_condi select_handler;
   s_m##.onchange :=
     make_selector_handler
       (set_selected_index s_m s_m_v options_month sig_month)
-      select_handler;
+      select_condi select_handler;
   (To_dom.of_element prev)##.onclick
-  := make_span_handler s_m sig_month ( - ) (fun () -> f_d (A.prev d `Month));
+  := make_span_handler s_m sig_month ( - )
+       (valid_period (A.prev d `Month))
+       (fun () -> f_d (A.prev d `Month));
   (To_dom.of_element next)##.onclick
-  := make_span_handler s_m sig_month ( + ) (fun () -> f_d (A.next d `Month));
+  := make_span_handler s_m sig_month ( + )
+       (valid_period (A.next d `Month))
+       (fun () -> f_d (A.next d `Month));
   (To_dom.of_element prev_year)##.onclick
-  := make_span_handler s_y sig_year ( - ) (fun () -> f_d (A.prev d `Year));
+  := make_span_handler s_y sig_year ( - )
+       (valid_period (A.prev d `Year))
+       (fun () -> f_d (A.prev d `Year));
   (To_dom.of_element next_year)##.onclick
-  := make_span_handler s_y sig_year ( + ) (fun () -> f_d (A.next d `Year))
+  := make_span_handler s_y sig_year ( + )
+       (valid_period (A.next d `Year))
+       (fun () -> f_d (A.next d `Year))
 
 let%client make
     :  ?init:int * int * int -> ?highlight:(int -> int -> int list Lwt.t)
     -> ?click_non_highlighted:bool -> ?update:(int * int * int) React.E.t
-    -> ?action:(int -> int -> int -> unit Lwt.t) -> ?button_labels:button_labels
+    -> ?action:(int -> int -> int -> unit Lwt.t)
+    -> ?period:A.field A.date * A.field A.date -> ?button_labels:button_labels
     -> ?intl:intl -> unit -> [> Html_types.table] elt
   =
  fun ?init ?highlight ?click_non_highlighted ?update ?action
+     ?(period = default_period.begin_p, default_period.end_p)
      ?(button_labels = default_button_labels) ?(intl = default_intl) () ->
+  let period = {begin_p = fst period; end_p = snd period} in
   let init, init_ym =
     let y, m, d =
       match init with
@@ -442,10 +487,10 @@ let%client make
   let d_ym, f_d_ym = React.S.create init_ym in
   let f d_ym =
     let ((cal, _, _, _, _, _, _) as c) =
-      build_calendar ~intl ~button_labels ~prehilight:init d_ym
+      build_calendar ~intl ~button_labels ~prehilight:init ~period d_ym
     in
-    attach_behavior ?highlight ?click_non_highlighted ?action ~intl d_ym c
-      f_d_ym;
+    attach_behavior ?highlight ?click_non_highlighted ?action ~intl ~period d_ym
+      c f_d_ym;
     cal
   in
   (match update with
@@ -466,16 +511,17 @@ let%server make
     -> ?click_non_highlighted:bool
     -> ?update:(int * int * int) React.E.t Eliom_client_value.t
     -> ?action:(int -> int -> int -> unit Lwt.t) Eliom_client_value.t
-    -> ?button_labels:button_labels -> ?intl:intl -> unit
-    -> [> Html_types.table] elt
+    -> ?period:A.field A.date * A.field A.date -> ?button_labels:button_labels
+    -> ?intl:intl -> unit -> [> Html_types.table] elt
   =
- fun ?init ?highlight ?click_non_highlighted ?update ?action ?button_labels
-     ?intl () ->
+ fun ?init ?highlight ?click_non_highlighted ?update ?action ?period
+     ?button_labels ?intl () ->
   C.node
     [%client
       (make ?init:~%init ?highlight:~%highlight
          ?click_non_highlighted:~%click_non_highlighted ?update:~%update
-         ?action:~%action ?intl:~%intl ?button_labels:~%button_labels ()
+         ?action:~%action ?period:~%period ?intl:~%intl
+         ?button_labels:~%button_labels ()
         : [> Html_types.table] elt)]
 
 let make_date_picker ?init ?update ?button_labels ?intl () =

--- a/src/widgets/ot_calendar.eliom
+++ b/src/widgets/ot_calendar.eliom
@@ -214,7 +214,7 @@ let rec build_calendar ?prehilight
     let month = A.month today |> string_of_month in
     let open D in
     select
-      ~a:[a_name "ot-c-select-month"]
+      ~a:[a_class ["ot-c-select-month"]]
       (default_intl.i_months
       |> List.map (fun m ->
              if month = m
@@ -224,7 +224,7 @@ let rec build_calendar ?prehilight
     let year = A.year today |> string_of_int in
     let open D in
     select
-      ~a:[a_name "ot-c-select-year"]
+      ~a:[a_class ["ot-c-select-year"]]
       (List.init
          A.(year period.end_p - year period.begin_p + 1)
          (fun i ->
@@ -239,12 +239,15 @@ let rec build_calendar ?prehilight
       [ tr
           [ th
               ~a:[a_colspan 7; a_class ["ot-c-header"]]
-              [ prev_year_button
-              ; prev_button
-              ; select_month
-              ; select_year
-              ; next_button
-              ; next_year_button ] ]
+              [ div
+                  ~a:[a_class ["ot-c-pv-nx-button"]]
+                  [prev_year_button; prev_button]
+              ; div
+                  ~a:[a_class ["ot-c-pv-nx-select"]]
+                  [select_month; select_year]
+              ; div
+                  ~a:[a_class ["ot-c-pv-nx-button"]]
+                  [next_button; next_year_button] ] ]
       ; tr (List.map (fun d -> th [txt d]) (get_rotated_days intl)) ]
   and f_cell i j =
     let d = CalendarLib.Calendar.Date.(add zero (Period.day (j + (7 * i)))) in

--- a/src/widgets/ot_calendar.eliomi
+++ b/src/widgets/ot_calendar.eliomi
@@ -45,6 +45,9 @@ val make
   -> ?click_non_highlighted:bool
   -> ?update:(int * int * int) React.E.t Eliom_client_value.t
   -> ?action:(int -> int -> int -> unit Lwt.t) Eliom_client_value.t
+  -> ?period:
+       CalendarLib.Date.field CalendarLib.Date.date
+       * CalendarLib.Date.field CalendarLib.Date.date
   -> ?button_labels:button_labels
   -> ?intl:intl
   -> unit
@@ -60,7 +63,11 @@ val make
     is provided) are clickable.
 
     If a client-side function [action] is provided, when the user
-    clicks on the date [d]:[m]:[y], [action y m d] is called. *)
+    clicks on the date [d]:[m]:[y], [action y m d] is called. 
+    
+    If [period] is provided, the calendar will have a period restriction
+    between the two dates given contained in [update].
+    *)
 
 val make_date_picker
   :  ?init:int * int * int


### PR DESCRIPTION
The focus here is on `src/widgets/ot_calendar.eliom` and `src/widgets/ot_calendar.eliomi`  files.

## Main visible changes

* Possibility to **change the month** via a selector
* Possibility to **change the year** via a selector as well
* When there is a period restriction the days that are not in the period are displayed differently and are not clickable anymore.

## Internal changes

* **Period restriction type** added in order to have a customizable calendar.
* **Refactoring** of the way the handlers were written in the file in order to avoid redundancies
* **Selectors** added for months and years
* **Handlers** added for months and years thanks to the (very) helpful `React` module.

## Test

In order to be able to test the changes, a very simple way to do is : 

* Clone this repository on your computer and pin (via opam : *opam pin add --kind path "your_path_to_this_repository"*) the repository as the new `ocaml-toolkit` library
* Download the `ocsigen-start` (via : *eliom-distillery -name ocstart -template os.pgocaml*) repository since it has a calendar demonstration 
* Reinstall the `ocaml-toolkit` (still via opam : *opam reinstall ocaml-toolkit*)
* The only thing left to do is to execute the program inside the `ocsigen-start` repository and see the changes in your favorite browser.