### PR TITLE
[ot-tip] Use document client width instead of window inner width

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-toolkit"
-version: "2.13.0"
+version: "3.0.1"
 maintainer: "dev@ocsigen.org"
 synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
 description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."

--- a/src/widgets/ot_tip.eliom
+++ b/src/widgets/ot_tip.eliom
@@ -47,11 +47,7 @@ let%client display ?(container_a = [a_class ["ot-tip-container"]])
     @@ Js.Optdef.get Dom_html.window##.innerHeight
     @@ fun () -> Dom_html.document##.documentElement##.clientHeight
   in
-  let d_width =
-    float
-    @@ Js.Optdef.get Dom_html.window##.innerWidth
-    @@ fun () -> Dom_html.document##.documentElement##.clientWidth
-  in
+  let d_width = float Dom_html.document##.documentElement##.clientWidth in
   let o_bounds = origin##getBoundingClientRect in
   let o_left = o_bounds##.left in
   let o_right = o_bounds##.right in


### PR DESCRIPTION
Since, by mistake, the previous PR () did not change the version,
the version which would have been at 3.0.0 is therefore now at 3.0.1 