### PR TITLE
[ot-tongue] improvements & fixes

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -15,7 +15,6 @@ indicate-multiline-delimiters = no
 infix-precedence = indent
 let-and = compact
 let-binding-spacing = compact
-let-open = auto
 module-item-spacing = compact
 parens-tuple = multi-line-only
 parens-tuple-patterns = multi-line-only

--- a/src/widgets/ot_tongue.eliom
+++ b/src/widgets/ot_tongue.eliom
@@ -21,7 +21,7 @@ let%client inertia_parameter1 = 0.1
    dx = average_speed * dt
    dx = initial_speed * dt / inertia_parameter1
 *)
-let%client inertia_parameter2 = 0.0001
+let%client inertia_parameter2 = 0.1
 (* Controls the movement duration, which depends on initial speed.
    Higher value, longer movement.
 *)

--- a/src/widgets/ot_tongue.eliom
+++ b/src/widgets/ot_tongue.eliom
@@ -154,6 +154,7 @@ let%client closest_stop ~speed ~maxsize size stops =
           *. inertia_parameter1 /. inertia_parameter2))
   in
   match
+    (* Computes the stop with the minimum distance *)
     List.fold_left
       (fun ((closest_d, _, _, _) as closest) (px, stop, interval_info) ->
         let d = abs (size - px) in
@@ -165,8 +166,10 @@ let%client closest_stop ~speed ~maxsize size stops =
       (max_int, 0, (`Px 0, true), `Point)
       stops
   with
-  | _, px, _, `Start when size >= px -> `Px size, false
-  | _, px, _, `End when size <= px -> `Px size, false
+  (* If we are in an interval we will return the number of pixels *)
+  | _, px, _, `Start when size > px -> `Px size, false
+  | _, px, _, `End when size < px -> `Px size, false
+  (* Otherwise we will return the stop *)
   | _, _, s, _ -> s
 
 let%client rec stop_after ~maxsize ~speed size stops =

--- a/src/widgets/ot_tongue.eliom
+++ b/src/widgets/ot_tongue.eliom
@@ -222,6 +222,7 @@ let%client bind side stops init handle update set_before_signal set_after_signal
   let startsize = ref 0 (* height or width of visible part in pixel *) in
   let animation_frame_requested = ref false in
   let set speed (stop, is_attractor) =
+    let previousstop = !currentstop in
     currentstop := stop;
     let duration =
       if is_attractor
@@ -232,7 +233,11 @@ let%client bind side stops init handle update set_before_signal set_after_signal
     elt'##.style##.transform := make_stop elt side stop;
     set_before_signal stop;
     Lwt.async (fun () ->
-        let%lwt _ = Lwt_js_events.transitionend elt' in
+        let%lwt () =
+          if stop <> previousstop
+          then Lwt_js_events.transitionend elt'
+          else Lwt.return_unit
+        in
         set_after_signal stop; Lwt.return_unit);
     Lwt.return_unit
   in

--- a/src/widgets/ot_tongue.eliom
+++ b/src/widgets/ot_tongue.eliom
@@ -1,9 +1,11 @@
-[%%shared open Eliom_content.Html
-          open Eliom_content.Html.F]
+[%%shared
+open Eliom_content.Html
+open Eliom_content.Html.F]
 
-[%%client open Lwt.Infix
-          open Js_of_ocaml
-          open Js_of_ocaml_lwt]
+[%%client
+open Lwt.Infix
+open Js_of_ocaml
+open Js_of_ocaml_lwt]
 
 let%client inertia_parameter1 = 0.1
 (* WARNING: inertia_parameter1 must be adapted to cubic-bezier in CSS!
@@ -28,7 +30,6 @@ let%client inertia_parameter3 = 0.5
    If large (1.0) high duration for high initial speed.
    dt = (inertia_parameter2 * speed)^inertia_parameter3
 *)
-
 type%shared simple_stop = [`Percent of int | `Px of int | `Full_content]
 
 type%shared stop =

--- a/src/widgets/ot_tongue.eliomi
+++ b/src/widgets/ot_tongue.eliomi
@@ -12,11 +12,13 @@ type tongue =
   { elt : Html_types.div Eliom_content.Html.D.elt
   ; stop_signal_before : simple_stop React.S.t Eliom_client_value.t
   ; stop_signal_after : simple_stop React.S.t Eliom_client_value.t
+  ; swipe_pos : int React.S.t Eliom_client_value.t
   ; px_signal_before : int React.S.t Eliom_client_value.t
   ; px_signal_after : int React.S.t Eliom_client_value.t }
 (** Signals contain the current
     position of the tongue, as a [simple_stop] or as [int].
-    Before (resp. after) signals are triggered before (resp. after) transition. *)
+    Before (resp. after) signals are triggered before (resp. after) transition.
+    [swipe_pos] represents the position during the swipe of the user *)
 
 val tongue
   :  ?a:[< Html_types.div_attrib] Eliom_content.Html.attrib list


### PR DESCRIPTION
This PR makes the ot-tongue more usable by fixing multiple bugs :

* We are now computing the speed of a swipe by taking into account all the positions during a swipe and not the 2 last positions.
* Before waiting for a transition to end in a ontouchend we check that there is a transition to execute.
* Intervals bounds are now considered as stops.
* Adding a new signal swipe_pos that represents the position of the user's finger position during a swipe.

Inertia parameters might need more tuning
