### PR TITLE
[ot-tongue-css] vh instead of % for initial translateY in Bottom case

### DIFF
--- a/css/ot_tongue.css
+++ b/css/ot_tongue.css
@@ -57,7 +57,7 @@
   padding-top: 70px;
   border-radius: 5px 5px 0 0;
   top: 0;
-  transform: translateY(100%);
+  transform: translateY(100vh);
   left: 0;
 }
 .ot-tongue-bottom::after {


### PR DESCRIPTION
We should use vh instead of % since in css attributes 'translate[Y|X]' percentage are based on the element's dimensions and not on the viewport's dimensions