### PR TITLE
Remove `lwt_ppx` dependency

### DIFF
--- a/Makefile.options
+++ b/Makefile.options
@@ -41,10 +41,10 @@ TEMPLATE_NAME := none.pgocaml
 
 # OCamlfind packages for the server
 SERVER_PACKAGES := calendar
-SERVER_PPX_PACKAGES := lwt_ppx js_of_ocaml-ppx_deriving_json
+SERVER_PPX_PACKAGES := js_of_ocaml-ppx_deriving_json
 # OCamlfind packages for the client
 CLIENT_PACKAGES := calendar js_of_ocaml js_of_ocaml-lwt
-CLIENT_PPX_PACKAGES := js_of_ocaml-ppx lwt_ppx js_of_ocaml-ppx_deriving_json
+CLIENT_PPX_PACKAGES := js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json
 
 # Debug package (yes/no): Debugging info in compilation
 DEBUG := yes

--- a/src/widgets/ot_calendar.eliom
+++ b/src/widgets/ot_calendar.eliom
@@ -33,6 +33,7 @@ type button_labels =
 
 [%%client.start]
 
+open Lwt.Syntax
 open Js_of_ocaml
 open Js_of_ocaml_lwt
 
@@ -344,7 +345,7 @@ let attach_events ?action ?(click_non_highlighted = false) ?update ~intl ~period
       | Some action ->
           fun _ r ->
             update_classes cal zero d;
-            let%lwt _ = action y m dom in
+            let* _ = action y m dom in
             Lwt.return_unit
       | None -> fun _ r -> update_classes cal zero d; Lwt.return_unit
     in
@@ -369,7 +370,7 @@ let attach_events_lwt ?action ?click_non_highlighted ~intl ~period d cal
   let f () =
     let m = CalendarLib.Date.(month d |> int_of_month)
     and y = CalendarLib.Date.year d in
-    let%lwt highlight = highlight y m in
+    let* highlight = highlight y m in
     attach_events ?action ?click_non_highlighted ~intl ~period d cal highlight;
     Lwt.return_unit
   in

--- a/src/widgets/ot_page_transition.eliom
+++ b/src/widgets/ot_page_transition.eliom
@@ -5,6 +5,7 @@ open Js_of_ocaml_lwt
 open Eliom_content
 open Html
 open Html.D
+open Lwt.Syntax
 
 type animation = Nil | Forward | Backward
 
@@ -70,14 +71,14 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
     Eliom_client.lock_request_handling ();
     Option.may Manip.appendToBody screenshot_wrapper;
     Manip.Class.add body cl_body_pre_forward;
-    let%lwt () = Lwt_js_events.request_animation_frame () in
-    let%lwt () = Lwt_js_events.request_animation_frame () in
+    let* () = Lwt_js_events.request_animation_frame () in
+    let* () = Lwt_js_events.request_animation_frame () in
     set_transition_duration body transition_duration;
     Option.may
       (fun sc -> Manip.Class.add sc cl_screenshot_post_forward)
       screenshot_container;
     Manip.Class.remove body cl_body_pre_forward;
-    let%lwt () = Lwt_js.sleep transition_duration in
+    let* () = Lwt_js.sleep transition_duration in
     Option.may Manip.removeSelf screenshot_wrapper;
     style##.transitionDuration := initial_transition_duration;
     Eliom_client.unlock_request_handling ();
@@ -89,7 +90,7 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
       Lwt.wakeup trigger_page_change ());
     let fa ss =
       Lwt.async @@ fun () ->
-      let%lwt () = wait_for_page_change in
+      let* () = wait_for_page_change in
       forward_animation_ transition_duration ss
     in
     let f screenshot = fa @@ Some screenshot in
@@ -104,10 +105,10 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
     in
     Eliom_client.lock_request_handling ();
     Manip.appendToBody screenshot_wrapper;
-    let%lwt () = Lwt_js_events.request_animation_frame () in
-    let%lwt () = Lwt_js_events.request_animation_frame () in
+    let* () = Lwt_js_events.request_animation_frame () in
+    let* () = Lwt_js_events.request_animation_frame () in
     Manip.Class.add screenshot_wrapper cl_wrapper_post_backward;
-    let%lwt () = Lwt_js.sleep transition_duration in
+    let* () = Lwt_js.sleep transition_duration in
     Manip.removeSelf screenshot_wrapper;
     Eliom_client.unlock_request_handling ();
     Lwt.return_unit
@@ -118,7 +119,7 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
       Lwt.wakeup trigger_page_change ());
     let ba ss =
       Lwt.async @@ fun () ->
-      let%lwt () = wait_for_page_change in
+      let* () = wait_for_page_change in
       backward_animation_ transition_duration ss
     in
     let f screenshot = ba @@ Some screenshot in

--- a/src/widgets/ot_picture_uploader.eliom
+++ b/src/widgets/ot_picture_uploader.eliom
@@ -21,6 +21,7 @@
 open Js_of_ocaml]
 
 [%%client open Js_of_ocaml_lwt]
+[%%client open Lwt.Syntax]
 [%%shared open Eliom_content.Html]
 [%%shared open Eliom_content.Html.F]
 
@@ -292,7 +293,7 @@ let%shared cropper ~(image : Dom_html.element Js.t Eliom_client_value.t)
                  (Dom_html.handler (fun ev -> handler (get_x ev) (get_y ev)))
                  (Js.bool false)
              in
-             let%lwt _ =
+             let* _ =
                Lwt.pick @@ List.map (fun e -> e Dom_html.document) rm_trigger
              in
              Dom_html.removeEventListener x;
@@ -458,7 +459,7 @@ let%client ocaml_service_upload ~service ~arg ?progress ?cropping file =
 
 let%client do_submit input ?progress ?cropping ~upload () =
   process_file input @@ fun file ->
-  let%lwt _ = upload ?progress ?cropping file in
+  let* _ = upload ?progress ?cropping file in
   Lwt.return_unit
 
 let%client bind_submit (input : Dom_html.inputElement Js.t Eliom_client_value.t)
@@ -468,7 +469,7 @@ let%client bind_submit (input : Dom_html.inputElement Js.t Eliom_client_value.t)
     Lwt_js_events.clicks button (fun ev _ ->
       Dom.preventDefault ev;
       Dom_html.stopPropagation ev;
-      let%lwt () = do_submit input ?cropping ~upload () in
+      let* () = do_submit input ?cropping ~upload () in
       after_submit ()))
 
 let%client bind ?container ~input ~preview ?crop ~submit ~upload ~after_submit

--- a/src/widgets/ot_pulltorefresh.eliom
+++ b/src/widgets/ot_pulltorefresh.eliom
@@ -14,6 +14,7 @@ let%shared default_header =
 
 [%%client
 open Js_of_ocaml
+open Lwt.Syntax
 
 module type CONF = sig
   val dragThreshold : float
@@ -98,10 +99,10 @@ module Make (Conf : CONF) = struct
          ("translateY(" ^ (string_of_float @@ Conf.dragThreshold) ^ "px)");
     refreshFlag := true;
     Lwt.async (fun () ->
-      let%lwt b =
+      let* b =
         Lwt.pick
           [ Conf.afterPull ()
-          ; (let%lwt () = Js_of_ocaml_lwt.Lwt_js.sleep Conf.timeout in
+          ; (let* () = Js_of_ocaml_lwt.Lwt_js.sleep Conf.timeout in
              Lwt.return_false) ]
       in
       if b

--- a/src/widgets/ot_swipe.eliom
+++ b/src/widgets/ot_swipe.eliom
@@ -3,6 +3,7 @@
 [%%shared open Js_of_ocaml]
 [%%client open Js_of_ocaml_lwt]
 open%client Eliom_content.Html
+open%client Lwt.Syntax
 [%%shared open Eliom_content.Html.F]
 
 (** sensibility for detecting swipe left/right or up/down *)
@@ -119,7 +120,7 @@ let%shared bind ?(transition_duration = 0.3)
            elt'##.style##.left := px_of_int left;
            Eliom_lib.Option.iter (fun f -> f ev left) ~%onend;
            Lwt.async (fun () ->
-             let%lwt _ = Lwt_js_events.transitionend elt' in
+             let* _ = Lwt_js_events.transitionend elt' in
              Manip.Class.remove elt "ot-swiping";
              Lwt.return_unit));
          status := Stopped;

--- a/src/widgets/ot_tongue.eliom
+++ b/src/widgets/ot_tongue.eliom
@@ -4,6 +4,7 @@ open Eliom_content.Html.F]
 
 [%%client
 open Lwt.Infix
+open Lwt.Syntax
 open Js_of_ocaml
 open Js_of_ocaml_lwt]
 
@@ -240,14 +241,14 @@ let%client bind side stops init handle update set_before_signal set_after_signal
       then None
       else Some Float.(pow (inertia_parameter2 *. abs speed) inertia_parameter3)
     in
-    let%lwt () = enable_transition ?duration elt in
+    let* () = enable_transition ?duration elt in
     elt'##.style##.transform := make_stop elt side stop;
     set_before_signal stop;
     Lwt.async (fun () ->
-      let%lwt () =
+      let* () =
         if stop <> previousstop
         then
-          let%lwt _ = Lwt_js_events.transitionend elt' in
+          let* _ = Lwt_js_events.transitionend elt' in
           Lwt.return_unit
         else Lwt.return_unit
       in
@@ -316,7 +317,7 @@ let%client bind side stops init handle update set_before_signal set_after_signal
     if not !animation_frame_requested
     then (
       animation_frame_requested := true;
-      let%lwt () = Lwt_js_events.request_animation_frame () in
+      let* () = Lwt_js_events.request_animation_frame () in
       animation_frame_requested := false;
       let d = sign * (!startpos - !currentpos) in
       let maxsize = full_size elt vert in
@@ -350,7 +351,7 @@ let%client bind side stops init handle update set_before_signal set_after_signal
     let a = touchmoves elt' ontouchmove in
     let b = touchend elt' >>= ontouchend in
     let c = touchcancel elt' >>= ontouchcancel in
-    let%lwt () = disable_transition elt in
+    let* () = disable_transition elt in
     (Js.Unsafe.coerce elt'##.style)##.transitionDuration := defaultduration;
     Lwt.pick [a; b; c]
   in
@@ -389,7 +390,7 @@ let%shared tongue ?(a = []) ?(side = `Bottom)
   ignore
     [%client
       (Lwt.async (fun () ->
-         let%lwt () = Ot_nodeready.nodeready (To_dom.of_element ~%elt) in
+         let* () = Ot_nodeready.nodeready (To_dom.of_element ~%elt) in
          bind ~%side ~%stops ~%init ~%handle
            ~%(update : simple_stop React.E.t Eliom_client_value.t option)
            (snd ~%before_signal) (snd ~%after_signal) (snd ~%swipe_pos) ~%elt;


### PR DESCRIPTION

This PR proposes to get rid of the `%lwt` syntax from `lwt_ppx` in favor of the
`Lwt_syntax`.

This is join work with @Julow (who wrote the tool making the automatic changes)

Most of the changes has been done automatically using the prototype tool
[here](https://github.com/Julow/lwt_ppx_to_let_syntax). This is the reason why
the PR is one big commit.

The `open Lwt.Syntax`s were not always placed at the right places as the syntax
is not necessarily used both on the client and server side in each file. This
has been fixed by hand.

I haven't understood the setup to run ocamlformat: it needs more arguments than
present in the `.ocamlformat` file and I haven't figure out all of them yet.
Nevertheless, this is also fixed by hand and the diff is minimal.

This is a first step toward moving from Lwt to effect-based concurrency. The
idea is to homogenize the syntax in order to have less cases to handle (again
by an automatic tool).

This is also an independent contribution, as it removes one dependency and one
preprocessor. Which can be considered a win by itself.