### PR TITLE
Enable and fix compiler warnings

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (vendored_dirs ocsigen-dune-rules)
 
 ; Install the CSS files into share/ocsigen-toolkit/css/
+
 (install
  (section share)
  (files

--- a/src/widgets/dune
+++ b/src/widgets/dune
@@ -1,8 +1,3 @@
-(env
- (_
-  (flags
-   (:standard -w +A-4-9-16-27-32-33-39-44-48-60-70))))
-
 (library
  (public_name ocsigen-toolkit.server)
  (name widgets_server)

--- a/src/widgets/ot_buttons.eliom
+++ b/src/widgets/ot_buttons.eliom
@@ -17,7 +17,7 @@ let%shared dropdown ?(a = []) ~menu content =
   ignore
     [%client
       (Lwt.async @@ fun () ->
-       Lwt_js_events.clicks (To_dom.of_element ~%dropdown) (fun ev _ ->
+       Lwt_js_events.clicks (To_dom.of_element ~%dropdown) (fun _ev _ ->
          Lwt.return_unit)
        : _)];
   dropdown

--- a/src/widgets/ot_calendar.eliom
+++ b/src/widgets/ot_calendar.eliom
@@ -130,24 +130,17 @@ let rec rotate_list ?(acc = []) l i =
     | h :: l -> rotate_list ~acc:(h :: acc) l (i - 1)
     | [] -> failwith "rotate_list"
 
-let get_rotated_days {i_days; i_start} =
+let get_rotated_days {i_days; i_start; _} =
   if List.length i_days != 7
   then invalid_arg "intl.i_days"
   else rotate_list i_days (int_of_dow i_start)
 
-let name_of_calendarlib_month {i_months} m =
+let name_of_calendarlib_month {i_months; _} m =
   if List.length i_months != 12
   then invalid_arg "intl.i_months"
   else List.nth i_months (CalendarLib.Date.int_of_month m - 1)
 
-let timezone_offset =
-  truncate (-.float (new%js Js.date_now)##getTimezoneOffset /. 60.)
-
 let ( >>! ) = Js.Opt.iter
-let user_tz = CalendarLib.Time_Zone.UTC_Plus timezone_offset
-let to_local date = CalendarLib.(Time_Zone.on Calendar.from_gmt user_tz date)
-let to_utc date = CalendarLib.(Time_Zone.on Calendar.to_gmt user_tz date)
-let now () = to_local (CalendarLib.Calendar.now ())
 
 let rec map_interval i j f =
   if i > j then [] else f i :: map_interval (i + 1) j f
@@ -168,7 +161,7 @@ let build_table i_max j_max ~a ~thead ~f_a_row ~f_cell =
   in
   D.table ~a ~thead (map_interval 0 i_max f)
 
-let fst_dow ~intl:{i_start} d =
+let fst_dow ~intl:{i_start; _} d =
   let open CalendarLib.Date in
   nth_weekday_of_month (year d) (month d) (calendarlib_of_dow i_start) 1
 
@@ -185,7 +178,7 @@ let select_action ?(size = 1) selector action =
       dom_select##.size := size;
       Lwt.return_unit))
 
-let rec build_calendar
+let build_calendar
           ?prehilight
           ~button_labels:{b_prev_year; b_prev_month; b_next_month; b_next_year}
           ~intl
@@ -273,7 +266,7 @@ let rec build_calendar
       ( [D.a_class classes]
       , [D.div [CalendarLib.Date.day_of_month d |> string_of_int |> D.txt]] )
     else [], []
-  and f_a_row i = [] in
+  and f_a_row _ = [] in
   ( build_table 5 6 ~a:[D.a_class ["ot-c-table"]] ~thead ~f_cell ~f_a_row
   , prev_button
   , next_button
@@ -333,7 +326,7 @@ let in_period_coerced
 let attach_events
       ?action
       ?(click_non_highlighted = false)
-      ?update
+      ?update:_
       ~intl
       ~period
       d
@@ -357,11 +350,11 @@ let attach_events
     let action =
       match action with
       | Some action ->
-          fun _ r ->
+          fun _ _ ->
             update_classes cal zero d;
             let* _ = action y m dom in
             Lwt.return_unit
-      | None -> fun _ r -> update_classes cal zero d; Lwt.return_unit
+      | None -> fun _ _ -> update_classes cal zero d; Lwt.return_unit
     in
     let set_onclick () =
       if in_period d ~begin_p:period.begin_p ~end_p:period.end_p

--- a/src/widgets/ot_carousel.eliom
+++ b/src/widgets/ot_carousel.eliom
@@ -462,7 +462,7 @@ let%shared
            then d2'##.offsetHeight, clY ev -. starty
            else d2'##.offsetWidth, clX ev -. startx
          in
-         let timestamp, speed =
+         let _timestamp, speed =
            compute_speed prev_speed prev_delta prev_timestamp delta
          in
          let pos = Eliom_shared.React.S.value pos_signal in
@@ -496,9 +496,9 @@ let%shared
              do_end ev startx starty speed delta timestamp
          | _ -> Lwt.return_unit
        in
-       let touchcancel ev _ =
+       let touchcancel _ev _ =
          match !status with
-         | Start (startx, starty, _) | Ongoing (startx, starty, _, _, _, _) ->
+         | Start _ | Ongoing _ ->
              add_transition d2';
              status := Stopped;
              let pos = Eliom_shared.React.S.value pos_signal in
@@ -508,7 +508,7 @@ let%shared
        if ~%swipeable
        then (
          Lwt.async (fun () ->
-           Lwt_js_events.touchstarts d (fun ev aa ->
+           Lwt_js_events.touchstarts d (fun ev _ ->
              status := Start (clX ev, clY ev, now ());
              Lwt.return_unit));
          Lwt.async (fun () -> Lwt_js_events.touchmoves d onpan);
@@ -938,7 +938,7 @@ let%shared
          React.S.value containerwidth - ul_width - initial_gap
        in
        Ot_swipe.bind ~min:fmin ~max:fmax
-         ~compute_final_pos:(fun ev p ->
+         ~compute_final_pos:(fun _ev p ->
            let cw = React.S.value containerwidth in
            let pos = max (-the_ul'##.scrollWidth + (cw / 2)) (min (cw / 2) p) in
            (* Limit the movement
@@ -956,7 +956,7 @@ let%shared
            set_curleft pos)
          ~onstart:(fun _ _ ->
            Eliom_lib.Option.iter remove_transition cursor_elt')
-         ~onend:(fun ev _ -> Eliom_lib.Option.iter add_transition cursor_elt')
+         ~onend:(fun _ev _ -> Eliom_lib.Option.iter add_transition cursor_elt')
          the_ul;
        Lwt.return_unit
        : _)];

--- a/src/widgets/ot_form.eliom
+++ b/src/widgets/ot_form.eliom
@@ -252,7 +252,6 @@ let%shared
            Eliom_lib.Dom_reference.retain ~%e
              ~keep:(React.S.map (fun x -> set_validity ~%e (f x)) ~%signal)
        | None -> ());
-      
        let f _ _ =
          let v = Js.to_string ~%e_with_value##.value in
          ~%set_signal v; Lwt.return_unit
@@ -477,7 +476,7 @@ let%shared
     [%client
       let disabled = Option.value ~default:false ~%disabled in
       if not disabled
-      then
+      then (
         let inp' = To_dom.of_input ~%inp in
         Eliom_lib.Dom_reference.retain inp'
           ~keep:
@@ -488,7 +487,7 @@ let%shared
           Lwt_js_events.changes inp' (fun _ _ ->
             ~%set_manually_changed true;
             ~%set_signal (Js.to_bool inp'##.checked);
-            Lwt.return_unit))]
+            Lwt.return_unit)))]
   in
   object
     method label = box
@@ -692,9 +691,7 @@ let%shared password_input ?(a = []) ?placeholder () =
 
 let%shared password_toggle inp =
   let inp = (inp : [< Html_types.input] elt :> Html_types.input elt) in
-  let toggle_icon =
-    D.span ~a:[a_class ["ot-password-toggle-show"]] []
-  in
+  let toggle_icon = D.span ~a:[a_class ["ot-password-toggle-show"]] [] in
   let toggle =
     D.button
       ~a:
@@ -707,27 +704,21 @@ let%shared password_toggle inp =
                 Dom.preventDefault ev;
                 let inp = To_dom.of_input ~%inp in
                 let icon = To_dom.of_element ~%toggle_icon in
-                let t =
-                  Js.to_string (Js.Unsafe.get inp (Js.string "type"))
-                in
+                let t = Js.to_string (Js.Unsafe.get inp (Js.string "type")) in
                 if t = "password"
                 then begin
-                  Js.Unsafe.set inp (Js.string "type")
-                    (Js.string "text");
-                  icon##.className :=
-                    Js.string "ot-password-toggle-hide"
+                  Js.Unsafe.set inp (Js.string "type") (Js.string "text");
+                  icon##.className := Js.string "ot-password-toggle-hide"
                 end
                 else begin
-                  Js.Unsafe.set inp (Js.string "type")
-                    (Js.string "password");
-                  icon##.className :=
-                    Js.string "ot-password-toggle-show"
+                  Js.Unsafe.set inp (Js.string "type") (Js.string "password");
+                  icon##.className := Js.string "ot-password-toggle-show"
                 end] ]
       [toggle_icon]
   in
-  D.div ~a:[a_class ["ot-password-container"]]
-    [ (inp : [< Html_types.input] elt :> Html_types.div_content_fun elt)
-    ; toggle ]
+  D.div
+    ~a:[a_class ["ot-password-container"]]
+    [(inp : [< Html_types.input] elt :> Html_types.div_content_fun elt); toggle]
 
 (* -- Prevent double submit --------------------------------------- *)
 
@@ -902,7 +893,9 @@ let%shared reactive_date_input ?(a = []) ?value () =
         ~keep:
           (React.S.map
              (fun v ->
-                let s = match v with Some d -> string_of_date d | None -> "" in
+                let s =
+                  match v with Some d -> string_of_date d | None -> ""
+                in
                 if Js.to_string inp'##.value <> s
                 then inp'##.value := Js.string s)
              ~%signal)]
@@ -936,7 +929,9 @@ let%shared reactive_time_input ?(a = []) ?value () =
         ~keep:
           (React.S.map
              (fun v ->
-                let s = match v with Some t -> string_of_time t | None -> "" in
+                let s =
+                  match v with Some t -> string_of_time t | None -> ""
+                in
                 if Js.to_string inp'##.value <> s
                 then inp'##.value := Js.string s)
              ~%signal)]
@@ -1019,4 +1014,3 @@ let%client prevent_tab elt =
 let%client setup_form element =
   let elts = tabbable_elts_of element in
   setup_tabcycle elts; focus_first elts
-

--- a/src/widgets/ot_form.eliomi
+++ b/src/widgets/ot_form.eliomi
@@ -288,8 +288,7 @@ val%shared password_input :
 
 (** {3 Password toggle (non-reactive)} *)
 
-val%shared password_toggle :
-  [< Html_types.input] elt -> [> `Div] elt
+val%shared password_toggle : [< Html_types.input] elt -> [> `Div] elt
 (** [password_toggle inp] wraps an existing password input element [inp]
     in a container with a visibility toggle button.
     Unlike {!password_input}, this does not use reactive signals: it

--- a/src/widgets/ot_nodeready.eliom
+++ b/src/widgets/ot_nodeready.eliom
@@ -55,12 +55,12 @@ let handler records observer =
   if !changes
   then (
     let ready, not_ready =
-      List.partition (fun {node} -> node_in_document node) !watched
+      List.partition (fun {node; _} -> node_in_document node) !watched
     in
     watched := not_ready;
     if not_ready = [] then observer##disconnect;
     ready
-    |> List.iter (fun {resolver; stop_ondead} ->
+    |> List.iter (fun {resolver; stop_ondead; _} ->
       stop_ondead (); Lwt.wakeup resolver ()))
 
 let observer =
@@ -81,8 +81,8 @@ let nodeready n =
   else (
     if !watched = [] then observer##observe Dom_html.document config;
     try
-      let {thread} =
-        List.find (fun {node} -> Js.strict_equals n node) !watched
+      let {thread; _} =
+        List.find (fun {node; _} -> Js.strict_equals n node) !watched
       in
       log ~n "already being watched";
       thread
@@ -95,11 +95,11 @@ let nodeready n =
       in
       Eliom_client.Page_status.ondead ~stop (fun () ->
         let instances_of_node, rest =
-          List.partition (fun {node} -> Js.strict_equals n node) !watched
+          List.partition (fun {node; _} -> Js.strict_equals n node) !watched
         in
         watched := rest;
         instances_of_node
-        |> List.iter (fun {resolver} ->
+        |> List.iter (fun {resolver; _} ->
           log ~n "deinstalled"; Lwt.wakeup resolver ()));
       watched := {node = n; thread = t; resolver = s; stop_ondead} :: !watched;
       log ~n "installed";

--- a/src/widgets/ot_noderesize.eliom
+++ b/src/widgets/ot_noderesize.eliom
@@ -79,7 +79,7 @@ let%client reset {grow; grow_child; shrink; _} =
   grow##.scrollLeft := Js.float (float grow##.scrollWidth);
   grow##.scrollTop := Js.float (float grow##.scrollHeight)
 
-let%client reset_opt {grow; grow_child; shrink; _} =
+let%client reset_opt {grow; shrink; _} =
   shrink##.scrollLeft := Js.float 9999.;
   shrink##.scrollTop := Js.float 9999.;
   grow##.scrollLeft := Js.float 9999.;

--- a/src/widgets/ot_page_transition.eliom
+++ b/src/widgets/ot_page_transition.eliom
@@ -46,7 +46,7 @@ end
 module Make (Conf : PAGE_TRANSITION_CONF) = struct
   type screenshot = Conf.screenshot
 
-  let wrap_screenshot ?(a = []) ~transition_duration ~screenshot =
+  let wrap_screenshot ?(a = []) ~transition_duration ~screenshot () =
     let container = Conf.screenshot_container screenshot in
     let wrapper = div ~a:(a_class [cl_wrapper] :: a) [container] in
     set_transition_duration wrapper transition_duration;
@@ -63,7 +63,7 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
           let screenshot_wrapper, screenshot_container =
             wrap_screenshot
               ~a:[a_class ["ot-page-transition-wrapper-forward"]]
-              ~transition_duration ~screenshot:(Some screenshot)
+              ~transition_duration ~screenshot:(Some screenshot) ()
           in
           Some screenshot_wrapper, Some screenshot_container
       | None -> None, None
@@ -101,7 +101,7 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
     let screenshot_wrapper, _ =
       wrap_screenshot
         ~a:[a_class ["ot-page-transition-wrapper-backward"]]
-        ~transition_duration ~screenshot
+        ~transition_duration ~screenshot ()
     in
     Eliom_client.lock_request_handling ();
     Manip.appendToBody screenshot_wrapper;
@@ -130,6 +130,7 @@ module Make (Conf : PAGE_TRANSITION_CONF) = struct
         ?transition_duration
         ~take_screenshot
         ~animation_type
+        ()
     =
     let rec hc_handler ev =
       Eliom_client.onchangepage hc_handler;

--- a/src/widgets/ot_page_transition.eliomi
+++ b/src/widgets/ot_page_transition.eliomi
@@ -42,6 +42,7 @@ module Make
       -> take_screenshot:((screenshot -> unit) -> unit)
       -> animation_type:(Eliom_client.changepage_event -> animation)
       -> unit
+      -> unit
   end
   with type screenshot = Conf.screenshot
 
@@ -49,6 +50,7 @@ val install_global_handler_withURI :
    ?transition_duration:float
   -> take_screenshot:((string -> unit) -> unit)
   -> animation_type:(Eliom_client.changepage_event -> animation)
+  -> unit
   -> unit
 (** [install_global_handler_withURI] enables you to skip the step of
     creating a module of type [PAGE_TRANSITION_CONF] when screenshots

--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -117,7 +117,7 @@ let%client
           ~a:
             [ a_button_type `Button
             ; a_class ["ot-popup-close"]
-            ; a_onclick (fun ev -> Lwt.async (fun () -> close ())) ]
+            ; a_onclick (fun _ev -> Lwt.async (fun () -> close ())) ]
           but
         :: content
     | None -> content

--- a/src/widgets/ot_range.eliom
+++ b/src/widgets/ot_range.eliom
@@ -28,12 +28,12 @@ let display_aux (_, _, a) v =
   and a = [D.a_class ["ot-r-value"]] in
   D.div ~a [D.txt v]
 
-let%client go_up (lb, ub, a) r (f : ?step:_ -> _) =
+let%client go_up (lb, ub, _a) r (f : ?step:_ -> _) =
   let v = Eliom_shared.React.S.value r in
   assert (v <= ub - 1);
   f (if v = ub - 1 then lb else v + 1)
 
-let%client go_down (lb, ub, a) r (f : ?step:_ -> _) =
+let%client go_down (lb, ub, _a) r (f : ?step:_ -> _) =
   let v = Eliom_shared.React.S.value r in
   assert (v >= lb);
   f (if v = lb then ub - 1 else v - 1)

--- a/src/widgets/ot_swipe.eliom
+++ b/src/widgets/ot_swipe.eliom
@@ -122,7 +122,7 @@ let%shared
          (* position when touch starts *)
        in
        let status = ref Stopped in
-       let onpanend ev aa =
+       let onpanend ev _ =
          if !status <> Start
          then (
            add_transition ~%transition_duration elt';
@@ -143,7 +143,7 @@ let%shared
          onpanstart0 ();
          Lwt.return_unit
        in
-       let onpan ev aa =
+       let onpan ev _ =
          let left = clX ev -. !startx in
          let do_pan left = elt'##.style##.left := px_of_int left in
          if !status = Start

--- a/src/widgets/ot_time_picker.eliom
+++ b/src/widgets/ot_time_picker.eliom
@@ -434,7 +434,7 @@ let make_hours_minutes_seq_24h
       Eliom_shared.Value.create
         (Eliom_shared.Value.local f_e_h)
         [%client
-          fun ?step ((x, b) as p) ->
+          fun ?step ((_, b) as p) ->
             ~%f_e_h ?step p;
             if b then ~%f_b false]
     in
@@ -503,7 +503,7 @@ let make_hours_minutes_seq ?action ?(init = 0, 0) ?update ?round_5 () =
     let e_h' = Eliom_shared.React.S.map [%shared fst] e_h
     and f_e_h =
       [%client
-        fun ?step ((x, b) as p) ->
+        fun ?step ((_, b) as p) ->
           ~%f_e_h ?step p;
           if b then ~%f_b false]
     in


### PR DESCRIPTION
This removes the warnings flags and fixes all the warnings reported by
the compiler.

Ot_page_transition signature changed due to unereasable labelled
arguments.