### PR TITLE
doc: odoc manual for the dev (modernize) API

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,8 +41,8 @@ jobs:
           # being built so odoc_driver documents these sources.
           opam install . --deps-only --with-doc
           opam install . --with-doc
-          # odoc-driver with the base_args fix (cross-library links). TODO: switch
-          # to the upstream release once the fix lands; until then pin the fork.
+          # odoc-driver with the cross-library link fix (driver: link units only
+          # against their actual lib deps). TODO: drop the pin once it lands upstream.
           opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
           opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
           opam install odoc odoc-driver

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -62,7 +62,7 @@ jobs:
         # site from doc/wodoc, and fetches the shared menu from ocsigen.github.io.
         run: >-
           opam exec -- wodoc build --config doc/wodoc
-          --menu https://ocsigen.org/wodoc/menu.html
+          --menu https://ocsigen.org/doc/menu.html
           --out "$PWD/_doc-site/dev" --label dev
 
       - name: Deploy to gh-pages (replace only dev/, keep the rest)

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,11 +16,16 @@ name: Documentation
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
 
 jobs:
   build-deploy:
-    if: github.repository == 'ocsigen/ocsigen-toolkit'
+    if: github.repository == 'ocsigen/ocsigen-toolkit' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -72,3 +77,46 @@ jobs:
           folder: _doc-site/dev
           target-folder: dev
           clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/ocsigen-toolkit' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,74 @@
+# Build the Ocsigen Toolkit documentation (manual + server/client API) with odoc_driver,
+# theme it with the Ocsigen chrome (wodoc), and publish it on the project's
+# gh-pages branch, served at https://ocsigen.org/ocsigen-toolkit/. See doc/README.md.
+#
+# CI deploys ONLY the "dev" docs and ONLY from master. Stable versions are built
+# by hand and committed to gh-pages at release time, so there is no dispatch /
+# release path here. Each run replaces only the dev/ directory; the other version
+# directories already on gh-pages are PRESERVED.
+#
+# PREREQUISITE: wodoc builds the API with `odoc_driver ocsigen-toolkit --remap` on the
+# INSTALLED ocsigen-toolkit, and its cross-library links need the odoc_driver `base_args`
+# fix, which is not yet upstreamed. Until it lands, the "Install dependencies" step
+# must pin odoc / odoc-driver from the patched source (see below).
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  build-deploy:
+    if: github.repository == 'ocsigen/ocsigen-toolkit'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install dependencies
+        run: |
+          # The documented version is the INSTALLED eliom: install it from the ref
+          # being built so odoc_driver documents these sources.
+          opam install . --deps-only --with-doc
+          opam install . --with-doc
+          # odoc-driver with the base_args fix (cross-library links). TODO: switch
+          # to the upstream release once the fix lands; until then pin the fork.
+          opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
+          opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
+          opam install odoc odoc-driver
+          # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Overlay the manual menu (lives on the wikidoc branch)
+        run: |
+          git fetch origin wikidoc
+          mkdir -p doc/manual
+          git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
+
+      - name: Build documentation (dev)
+        # wodoc build runs `odoc_driver ocsigen-toolkit --remap` on the installed package
+        # (after preprocessing the installed manual .mld), assembles the themed
+        # site from doc/wodoc, and fetches the shared menu from ocsigen.github.io.
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/wodoc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -43,8 +43,8 @@ jobs:
           opam install . --with-doc
           # odoc-driver with the cross-library link fix (driver: link units only
           # against their actual lib deps). TODO: drop the pin once it lands upstream.
-          opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
-          opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
+          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
           opam install odoc odoc-driver
           # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -55,12 +55,6 @@ jobs:
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
 
-      - name: Overlay the manual menu (lives on the wikidoc branch)
-        run: |
-          git fetch origin wikidoc
-          mkdir -p doc/manual
-          git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
-
       - name: Build documentation (dev)
         # wodoc build runs `odoc_driver ocsigen-toolkit --remap` on the installed package
         # (after preprocessing the installed manual .mld), assembles the themed

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+doc/manual/menu.wiki

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,50 @@
+# How the Ocsigen Toolkit documentation is generated
+
+The Ocsigen Toolkit documentation published at <https://ocsigen.org/ocsigen-toolkit/>
+is built with **odoc** and themed with the Ocsigen site chrome by
+[**wodoc**](https://github.com/ocsigen/wodoc) (an odoc driver).
+
+Ocsigen Toolkit is a **client/server** project: it ships its server and client
+APIs as two libraries of the same package (`ocsigen-toolkit.server` /
+`ocsigen-toolkit.client`) with the **same module names**, so `dune build @doc`
+collides. The API is therefore built with `odoc_driver ocsigen-toolkit --remap`
+on the **installed** package — the documented version is whatever the build
+switch has installed.
+
+## Sources
+
+| What | Where | Format |
+|---|---|---|
+| Manual | the package's `(documentation)` `.mld` (built with the API) | odoc pages |
+| Manual nav order | `doc/manual/menu.wiki` (overlaid from the `wikidoc` branch by CI) | wiki menu |
+| Server / client API | `doc/server.indexdoc` / `doc/client.indexdoc` | odoc index |
+| Site configuration | [`doc/wodoc`](wodoc) | wodoc config (S-expression) |
+
+The whole site — per-side API navs, the client/server switch, the body colour,
+the shared manual nav and the relative cross-links into sibling Ocsigen projects
+— is declared in [`doc/wodoc`](wodoc) and produced by a single `wodoc build`.
+There is **no `build.sh`** and no Python.
+
+## Build
+
+```
+opam install . --with-doc        # the version to document (installed)
+opam install wodoc
+git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
+wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
+  --menu https://ocsigen.org/wodoc/menu.html
+```
+
+> **Prerequisite (CI).** The cross-library links need the `odoc_driver`
+> `base_args` fix, not yet upstreamed; CI must pin `odoc` / `odoc-driver` from the
+> patched source until it lands (see the workflow comments).
+
+## Deployment (CI)
+
+[`.github/workflows/doc.yml`](../.github/workflows/doc.yml) deploys to **`gh-pages`**
+(served at `ocsigen.org/ocsigen-toolkit/`). The CI triggers **only on `master`**:
+
+- **push to `master`** → rebuilds and deploys the **`dev`** docs only.
+
+Stable versions are built by hand and committed to `gh-pages` (with `latest`
+repointed) at release time. Each CI run replaces only the `dev/` directory.

--- a/doc/README.md
+++ b/doc/README.md
@@ -48,3 +48,22 @@ wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
 
 Stable versions are built by hand and committed to `gh-pages` (with `latest`
 repointed) at release time. Each CI run replaces only the `dev/` directory.
+
+## Releasing a stable version
+
+The CI only ever (re)builds `dev/`. A stable version is a **frozen snapshot** of
+`dev/` plus the `latest` symlink, produced at release time on the `gh-pages`
+branch (no rebuild — the docs of a release are exactly the `dev` docs at that
+point):
+
+```
+git fetch origin gh-pages
+git worktree add gh-pages gh-pages && cd gh-pages
+cp -a dev <version>          # e.g. freeze the current dev docs as 1.2.3
+ln -sfn <version> latest     # point `latest` at the new release
+git add <version> latest && git commit -m "Release doc <version>" && git push
+```
+
+The project-root `index.html` redirects to `latest/`, so nothing else changes.
+Older version directories are preserved untouched. (This freeze step is a good
+candidate for a future `wodoc release` subcommand.)

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,7 +32,7 @@ opam install . --with-doc        # the version to document (installed)
 opam install wodoc
 git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
 wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
-  --menu https://ocsigen.org/wodoc/menu.html
+  --menu https://ocsigen.org/doc/menu.html
 ```
 
 > **Prerequisite (CI).** The cross-library links need the `odoc_driver`

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,5 @@
+; Ocsigen Toolkit manual pages (odoc .mld), compiled in place with the API by
+; `dune build @doc` and installed with the package, so they appear on ocaml.org
+; and resolve {{!page-X}} / {!Module} references against the API.
+(documentation
+ (package ocsigen-toolkit))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,23 @@
+{0 Ocsigen Toolkit}
+
+Ocsigen Toolkit is a set of reusable user-interface widgets for
+{{:../eliom}Eliom} applications. The widgets can be produced on the
+server or on the client from the same code, which makes them
+particularly suited to mobile, client-server applications.
+
+Ocsigen Toolkit is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Documentation}
+
+- {{!page-intro}Introduction} — installation, programming style and an
+  overview of the available widgets.
+- The server and client API of every widget (use the {e Server API} /
+  {e Client API} switch to move between the two sides).
+
+{1 Installation}
+
+Ocsigen Toolkit is available via OPAM:
+
+{[
+opam install ocsigen-toolkit
+]}

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,7 +1,7 @@
 {0 Ocsigen Toolkit}
 
 Ocsigen Toolkit is a set of reusable user-interface widgets for
-{{:../eliom}Eliom} applications. The widgets can be produced on the
+{{:/eliom/}Eliom} applications. The widgets can be produced on the
 server or on the client from the same code, which makes them
 particularly suited to mobile, client-server applications.
 

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -4,7 +4,7 @@ Ocsigen Toolkit provides various user interface widgets and related
 utilities that assist in the rapid development of interactive Web
 applications.
 
-Ocsigen Toolkit is built with {{:../eliom}Eliom}.
+Ocsigen Toolkit is built with {{:/eliom/}Eliom}.
 
 {1 Installation and getting started}
 
@@ -15,10 +15,10 @@ opam install ocsigen-toolkit
 v}
 
 You may want to use Ocsigen Toolkit in conjunction with
-{{:../ocsigen-start}Ocsigen Start}, which provides an application
+{{:/ocsigen-start/}Ocsigen Start}, which provides an application
 template for quickly getting started with Ocsigen. The template
 provides various runnable examples of Ocsigen Toolkit widgets. See the
-{{:../ocsigen-start/intro.html}Ocsigen Start
+{{:/ocsigen-start/latest/intro.html}Ocsigen Start
 manual} for details.
 
 {1 Programming style}
@@ -30,7 +30,7 @@ sections. The server instance of the code can be used to produce pages
 (with Ocsigen Toolkit widgets) during traditional Web interaction,
 while the client instance can be used to render the same pages and
 widgets on a mobile device without contacting the server. See the
-{{:../eliom/mobile-apps.html}mobile applications
+{{:/eliom/latest/mobile-apps.html}mobile applications
 section} of the Eliom manual for details.
 
 The widgets generally follow a reactive programming style. We use
@@ -38,7 +38,7 @@ The widgets generally follow a reactive programming style. We use
 extensively, which allows us to produce this reactive content on both
 sides.
 See
-{{:../eliom/clientserver-react.html}the respective manual chapter}
+{{:/eliom/latest/clientserver-react.html}the respective manual chapter}
 for more info.
 {!Eliom.Shared}
 signals and events appear in the Ocsigen Toolkit APIs, and can be used

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -1,0 +1,105 @@
+{0 Introduction}
+
+Ocsigen Toolkit provides various user interface widgets and related
+utilities that assist in the rapid development of interactive Web
+applications.
+
+Ocsigen Toolkit is built with {{:../eliom}Eliom}.
+
+{1 Installation and getting started}
+
+You can install Ocsigen Toolkit via OPAM:
+
+{v
+opam install ocsigen-toolkit
+v}
+
+You may want to use Ocsigen Toolkit in conjunction with
+{{:../ocsigen-start}Ocsigen Start}, which provides an application
+template for quickly getting started with Ocsigen. The template
+provides various runnable examples of Ocsigen Toolkit widgets. See the
+{{:../ocsigen-start/intro.html}Ocsigen Start
+manual} for details.
+
+{1 Programming style}
+
+Most of the Ocsigen Toolkit widgets can be produced invariably on the
+server or on the client (with the same code). This enables a
+mobile-friendly programming paradigm, where most code lies in shared
+sections. The server instance of the code can be used to produce pages
+(with Ocsigen Toolkit widgets) during traditional Web interaction,
+while the client instance can be used to render the same pages and
+widgets on a mobile device without contacting the server. See the
+{{:../eliom/mobile-apps.html}mobile applications
+section} of the Eliom manual for details.
+
+The widgets generally follow a reactive programming style. We use
+{!Eliom.Shared}
+extensively, which allows us to produce this reactive content on both
+sides.
+See
+{{:../eliom/clientserver-react.html}the respective manual chapter}
+for more info.
+{!Eliom.Shared}
+signals and events appear in the Ocsigen Toolkit APIs, and can be used
+as a mechanism for composing different widgets.
+
+{1 CSS}
+
+Most widgets need appropriate CSS to display properly. We provide
+default CSS files, normally installed in
+
+[~/.opam/${SWITCH}/share/ocsigen-toolkit/css/]
+
+Ocsigen Start uses these files by default. If your application does
+not use Ocsigen Start, you will need to include the CSS manually.
+
+Of course, you are free to modify the style to suit the desired look.
+
+{1 Widgets overview}
+
+- {!Ot.Buttons}:
+  provides a dropdown menu widget
+- {!Ot.Calendar}:
+  calendar widget, allowing the user to pick dates
+- {!Ot.Carousel}:
+  container for blocks, only one of which is displayed at a time,
+  with various ways to move between them (buttons, swipe, keyboard arrows)
+- {!Ot.Tongue}:
+  swipable element appearing from one side of the screen
+- {!Ot.Color_picker}:
+  color picker widget
+- {!Ot.Drawer}:
+  a drawer menu that typically appears on an edge of the screen.
+  It can  appear/disappear via buttons or by swiping.
+- {!Ot.Picture_uploader}:
+  user interface for uploading pictures
+- {!Ot.Popup}:
+  popup windows that can be controlled in various ways
+- {!Ot.Range}:
+  widget for picking one among a range of values
+- {!Ot.Spinner}:
+  a spinner that appears while we wait for "slow" HTML content to be
+  generated
+- {!Ot.Swipe}:
+  make element swipeable on touch screens
+- {!Ot.Time_picker}:
+  clock-like widget that allows the user to pick a time
+- {!Ot.Toggle}:
+  binary toggle widget
+
+{2 Non-widget utilities}
+
+- {!Ot.Nodeready}:
+  produces an Lwt thread allowing one to wait for a node to be
+  inserted in the DOM
+- {!Ot.Noderesize}:
+  listen to element resize events
+- {!Ot.Size}:
+  utilities to deal with DOM element dimensions
+- {!Ot.Lib}:
+  functions useful for other widgets
+- {!Ot.Sticky}:
+  make elements "sticky", i.e., do not let them go out of sight
+- {!Ot.Style}:
+  an interface to [Window.getComputedStyle()]

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,21 @@
+;; Declarative wodoc config for the Ocsigen Toolkit documentation (client/server).
+;;   wodoc build --config doc/wodoc --out <dir>/<label> --label <v> \
+;;               --menu https://ocsigen.org/wodoc/menu.html [--local]
+;; ocsigen-toolkit ships server and client libraries (ocsigen-toolkit.server /
+;; ocsigen-toolkit.client) with the same module names, so the API is built with
+;; `odoc_driver ocsigen-toolkit --remap` on the INSTALLED package. Each side gets
+;; its own API nav, a body colour and a switch; the manual nav is shared.
+(project ocsigen-toolkit)
+(title Toolkit)
+(pub /ocsigen-toolkit)
+(odoc-driver ocsigen-toolkit)
+(landing ocsigen-toolkit/index.html)
+(manual-menu doc/manual/menu.wiki)
+(client-server
+  (server (lib ocsigen-toolkit.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Ot))
+  (client (lib ocsigen-toolkit.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Ot)))
+(hosted
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -10,7 +10,9 @@
 (pub /ocsigen-toolkit)
 (odoc-driver ocsigen-toolkit)
 (landing intro.html)
-(manual-menu doc/manual/menu.wiki)
+(nav
+ (section "Ocsigen Toolkit"
+  (link "Introduction" intro.html intro)))
 (client-server
   (server (lib ocsigen-toolkit.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Ot))
   (client (lib ocsigen-toolkit.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Ot)))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -9,7 +9,7 @@
 (title Toolkit)
 (pub /ocsigen-toolkit)
 (odoc-driver ocsigen-toolkit)
-(landing ocsigen-toolkit/index.html)
+(landing intro.html)
 (manual-menu doc/manual/menu.wiki)
 (client-server
   (server (lib ocsigen-toolkit.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Ot))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -16,8 +16,15 @@
 (client-server
   (server (lib ocsigen-toolkit.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Ot))
   (client (lib ocsigen-toolkit.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Ot)))
+;; Sibling Ocsigen projects whose ocaml.org xrefs are rewritten to relative
+;; links into their wodoc docs:  (pkg deploy-dir layout wrapper-module)
+;; layout = true/multilib (<dir>.<side>/) | false/root (modules at version
+;; root) | subdir (each opam package under its own <pkg>/, whole family).
 (hosted
   (eliom           eliom           true  Eliom)
   (ocsigen-toolkit ocsigen-toolkit true  Ot)
   (ocsigen-start   ocsigen-start   true  Os)
-  (ocsigenserver   ocsigenserver   false Ocsigen))
+  (ocsigenserver   ocsigenserver   false Ocsigen)
+  (js_of_ocaml     js_of_ocaml     subdir)
+  (tyxml           tyxml           subdir)
+  (reactiveData    reactiveData    root))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,6 +1,6 @@
 ;; Declarative wodoc config for the Ocsigen Toolkit documentation (client/server).
 ;;   wodoc build --config doc/wodoc --out <dir>/<label> --label <v> \
-;;               --menu https://ocsigen.org/wodoc/menu.html [--local]
+;;               --menu https://ocsigen.org/doc/menu.html [--local]
 ;; ocsigen-toolkit ships server and client libraries (ocsigen-toolkit.server /
 ;; ocsigen-toolkit.client) with the same module names, so the API is built with
 ;; `odoc_driver ocsigen-toolkit --remap` on the INSTALLED package. Each side gets


### PR DESCRIPTION
Adds the Ocsigen Toolkit documentation (manual) as odoc `.mld` pages, built
in-package with the API so the whole doc is generated by odoc/`dune build @doc`
and ships on ocaml.org — part of the ocsigen.org → wodoc/odoc migration.

This is the **dev** branch (off `modernize`, modules `Ot.Xxx`).

**Changes**
- `doc/intro.mld` — the manual introduction, converted from the wikicreole
  source (`wikidoc:doc/dev/manual/intro.wiki`) with `wodoc convert --odoc-refs`.
  Cross-package API references use native odoc refs (`{!Ot.Popup}`,
  `{!Eliom.Shared}`); cross-project links are relative; the removed
  `Ot.Social_meta` entry was dropped.
- `doc/index.mld` — package landing page (overview + link to the manual).
- `doc/dune` — `(documentation (package ocsigen-toolkit))` so the `.mld` are
  compiled in the same odoc run as the API and `{{!page-X}}` / `{!Module}`
  references resolve.

The themed HTML is built by `ocsigen.github.io:wodoc/ocsigen-toolkit/build.sh`
(patched odoc-driver, since the server/client libraries share module names) and
is previewed at https://ocsigen.org/wodoc/ocsigen-toolkit/dev/ .

Draft: the manual still references `Ot.Social_meta`-era content elsewhere; kept
as draft until the wider wodoc rollout is finalised.
