### PR TITLE
doc: odoc manual for the stable (master) API

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,10 +7,9 @@
 # release path here. Each run replaces only the dev/ directory; the other version
 # directories already on gh-pages are PRESERVED.
 #
-# PREREQUISITE: wodoc builds the API with `odoc_driver ocsigen-toolkit --remap` on the
-# INSTALLED ocsigen-toolkit, and its cross-library links need the odoc_driver `base_args`
-# fix, which is not yet upstreamed. Until it lands, the "Install dependencies" step
-# must pin odoc / odoc-driver from the patched source (see below).
+# wodoc builds the API with `odoc_driver ocsigen-toolkit --remap` on the INSTALLED
+# ocsigen-toolkit. The cross-library link fix lives in the balat/odoc fork, which
+# wodoc pulls in via its opam pin-depends -- so we do NOT pin odoc ourselves here.
 name: Documentation
 
 on:
@@ -47,18 +46,26 @@ jobs:
         with:
           ocaml-compiler: "5.4.0"
 
+      - name: Set up Binaryen
+        # ocsigen-toolkit depends on wasm_of_ocaml-compiler, whose build needs a
+        # recent binaryen (wasm-merge); distro binaryen is too old. Same action as
+        # js_of_ocaml's own CI.
+        uses: Aandreba/setup-binaryen@v1.0.0
+        with:
+          token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
-          # The documented version is the INSTALLED eliom: install it from the ref
-          # being built so odoc_driver documents these sources.
+          # Install ocsigen-toolkit (from the ref being built) so odoc_driver
+          # documents these sources. It is installed WITHOUT --with-doc: its server
+          # and client libraries share module names, so building its own @doc
+          # collides ("Multiple rules for .../Ot_*/index.html"). wodoc builds the
+          # docs via `odoc_driver --remap` instead.
           opam install . --deps-only --with-doc
-          opam install . --with-doc
-          # odoc-driver with the cross-library link fix (driver: link units only
-          # against their actual lib deps). TODO: drop the pin once it lands upstream.
-          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
-          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
-          opam install odoc odoc-driver
-          # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
+          opam install .
+          # wodoc themes the pages. Its opam pin-depends pulls odoc / odoc-driver
+          # from the balat/odoc fork (the cross-library link fix, not yet upstream),
+          # so we do NOT pin odoc ourselves here.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,6 +23,13 @@ on:
         required: false
         default: ""
 
+# Serialise gh-pages writes: a push (rebuilds dev/) and a release
+# workflow_dispatch (freezes <version>/ and repoints latest) must never push to
+# gh-pages at the same time, or the second push fails non-fast-forward.
+concurrency:
+  group: doc-deploy-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build-deploy:
     if: github.repository == 'ocsigen/ocsigen-toolkit' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
@@ -78,6 +85,10 @@ jobs:
     # No rebuild -- the docs of a release are exactly the dev docs at that point.
     if: github.repository == 'ocsigen/ocsigen-toolkit' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
     runs-on: ubuntu-latest
+    # Pass the user-supplied version through the environment; never interpolate
+    # it directly into a run: shell (avoids command injection from the input).
+    env:
+      VERSION: ${{ github.event.inputs.version }}
     permissions:
       contents: write
     steps:
@@ -103,7 +114,7 @@ jobs:
         # write the root index.html redirect if missing, refresh versions.json.
         run: >-
           opam exec -- wodoc release --site site --from dev
-          --version "${{ github.event.inputs.version }}"
+          --version "$VERSION"
 
       - name: Commit and push gh-pages
         run: |
@@ -112,5 +123,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --cached --quiet \
-            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+            || git commit -m "Release doc $VERSION (freeze dev, repoint latest)"
           git push

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,116 @@
+# Build the Ocsigen Toolkit documentation (manual + server/client API) with odoc_driver,
+# theme it with the Ocsigen chrome (wodoc), and publish it on the project's
+# gh-pages branch, served at https://ocsigen.org/ocsigen-toolkit/. See doc/README.md.
+#
+# CI deploys ONLY the "dev" docs and ONLY from master. Stable versions are built
+# by hand and committed to gh-pages at release time, so there is no dispatch /
+# release path here. Each run replaces only the dev/ directory; the other version
+# directories already on gh-pages are PRESERVED.
+#
+# PREREQUISITE: wodoc builds the API with `odoc_driver ocsigen-toolkit --remap` on the
+# INSTALLED ocsigen-toolkit, and its cross-library links need the odoc_driver `base_args`
+# fix, which is not yet upstreamed. Until it lands, the "Install dependencies" step
+# must pin odoc / odoc-driver from the patched source (see below).
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
+
+jobs:
+  build-deploy:
+    if: github.repository == 'ocsigen/ocsigen-toolkit' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install dependencies
+        run: |
+          # The documented version is the INSTALLED eliom: install it from the ref
+          # being built so odoc_driver documents these sources.
+          opam install . --deps-only --with-doc
+          opam install . --with-doc
+          # odoc-driver with the cross-library link fix (driver: link units only
+          # against their actual lib deps). TODO: drop the pin once it lands upstream.
+          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam install odoc odoc-driver
+          # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Build documentation (dev)
+        # wodoc build runs `odoc_driver ocsigen-toolkit --remap` on the installed package
+        # (after preprocessing the installed manual .mld), assembles the themed
+        # site from doc/wodoc, and fetches the shared menu from ocsigen.github.io.
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/doc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/ocsigen-toolkit' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,83 @@
+# How the Ocsigen Toolkit documentation is generated
+
+The Ocsigen Toolkit documentation published at
+<https://ocsigen.org/ocsigen-toolkit/> is built with **odoc** and themed with the
+Ocsigen site chrome by [**wodoc**](https://github.com/ocsigen/wodoc) (an odoc
+driver). The same odoc sources are also what ocaml.org renders.
+
+Ocsigen Toolkit is a **client/server** project: it ships its server and client
+APIs as two libraries of the same package (`ocsigen-toolkit.server` /
+`ocsigen-toolkit.client`) with the **same module names**, so `dune build @doc`
+collides. The API is therefore built with `odoc_driver ocsigen-toolkit --remap`
+(the engine ocaml.org uses) on the **installed** package — i.e. the documented
+version is whatever the build switch has installed.
+
+## Sources
+
+| What | Where | Format |
+|---|---|---|
+| Manual | the package's `(documentation)` `.mld` (`doc/*.mld`) | odoc pages |
+| Manual nav | the static `(nav …)` in [`doc/wodoc`](wodoc) | wodoc config |
+| Server / client API | the installed `ocsigen-toolkit.server` / `.client` libraries | odoc comments |
+| Site configuration | [`doc/wodoc`](wodoc) | wodoc config (S-expression) |
+
+The whole site — per-side API navs, the client/server switch, the body colour,
+the shared manual nav, and the rewriting of sibling Ocsigen projects' cross-refs
+to relative links — is declared in [`doc/wodoc`](wodoc) and produced by a single
+`wodoc build`. There is **no `build.sh`** and no Python.
+
+## Build
+
+`wodoc build` documents the **installed** `ocsigen-toolkit`, so install it first
+(from the ref you want to document) in a switch that also has `wodoc`:
+
+```
+opam install .                       # the version to document (NOT --with-doc:
+                                     # server+client share module names -> @doc collides)
+opam install wodoc                   # the odoc driver / theming
+wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
+  --menu https://ocsigen.org/doc/menu.html
+```
+
+`wodoc build` runs `odoc_driver ocsigen-toolkit --remap` on the installed
+package, assembles every page into the Ocsigen site and writes the version
+redirect. Add `--local` to fetch the shared `/css//img/` assets and preview offline.
+
+> **Toolchain (CI).** The cross-library link fix lives in the
+> [balat/odoc](https://github.com/balat/odoc) fork, which wodoc pulls in through
+> its opam `pin-depends`. Do **not** pin `odoc` yourself — that conflicts with
+> wodoc's pin. `wasm_of_ocaml-compiler` (a client-toolchain dep) needs a recent
+> binaryen, installed by the `Set up Binaryen` CI step.
+
+## Deployment (CI)
+
+[`.github/workflows/doc.yml`](../.github/workflows/doc.yml) builds and publishes to
+the project's **`gh-pages`** branch (served at `ocsigen.org/ocsigen-toolkit/`). The
+CI triggers **only on `master`**, so pushing any other branch never deploys:
+
+- **push to `master`** → rebuilds and deploys the **`dev`** docs only.
+
+Stable versions are **not** built by CI on push: they are published by the
+`release` job (below). Each CI run replaces only the `dev/` directory; the other
+version directories already on `gh-pages` are preserved.
+
+## Releasing a stable version
+
+The CI builds only `dev/`. To publish a stable version, trigger the
+**Documentation** workflow's `release` job with the **version** input — either:
+
+- **CLI** (from a clone of the repo): `gh workflow run doc.yml -f version=1.2.3`
+- **GitHub UI**: repo → *Actions* → *Documentation* (left sidebar) → *Run workflow*
+  (top-right) → set **version** (e.g. `1.2.3`) → *Run workflow*.
+
+The `release` job freezes the current `dev/` docs as `/<version>/`, repoints the
+`latest` symlink, writes the root redirect and refreshes `versions.json` — via
+`wodoc release --from dev --version <version>`. No rebuild: the docs of a release
+are exactly the `dev` docs at that point.
+
+Equivalently, by hand on a `gh-pages` checkout:
+
+```
+wodoc release --site . --from dev --version <version>
+git add -A && git commit -m "Release doc <version>" && git push
+```

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,5 @@
+; Ocsigen Toolkit manual pages (odoc .mld), compiled in place with the API by
+; `dune build @doc` and installed with the package, so they appear on ocaml.org
+; and resolve {{!page-X}} / {!Module} references against the API.
+(documentation
+ (package ocsigen-toolkit))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,23 @@
+{0 Ocsigen Toolkit}
+
+Ocsigen Toolkit is a set of reusable user-interface widgets for
+{{:../eliom}Eliom} applications. The widgets can be produced on the
+server or on the client from the same code, which makes them
+particularly suited to mobile, client-server applications.
+
+Ocsigen Toolkit is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Documentation}
+
+- {{!page-intro}Introduction} — installation, programming style and an
+  overview of the available widgets.
+- The server and client API of every widget (use the {e Server API} /
+  {e Client API} switch to move between the two sides).
+
+{1 Installation}
+
+Ocsigen Toolkit is available via OPAM:
+
+{[
+opam install ocsigen-toolkit
+]}

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,7 +1,7 @@
 {0 Ocsigen Toolkit}
 
 Ocsigen Toolkit is a set of reusable user-interface widgets for
-{{:/eliom/}Eliom} applications. The widgets can be produced on the
+{{:https://ocsigen.org/eliom/}Eliom} applications. The widgets can be produced on the
 server or on the client from the same code, which makes them
 particularly suited to mobile, client-server applications.
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,7 +1,7 @@
 {0 Ocsigen Toolkit}
 
 Ocsigen Toolkit is a set of reusable user-interface widgets for
-{{:../eliom}Eliom} applications. The widgets can be produced on the
+{{:/eliom/}Eliom} applications. The widgets can be produced on the
 server or on the client from the same code, which makes them
 particularly suited to mobile, client-server applications.
 

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -4,7 +4,7 @@ Ocsigen Toolkit provides various user interface widgets and related
 utilities that assist in the rapid development of interactive Web
 applications.
 
-Ocsigen Toolkit is built with {{:/eliom/}Eliom}.
+Ocsigen Toolkit is built with {{:https://ocsigen.org/eliom/}Eliom}.
 
 {1 Installation and getting started}
 
@@ -15,14 +15,14 @@ opam install ocsigen-toolkit
 v}
 
 You may want to use Ocsigen Toolkit in conjunction with
-{{:/ocsigen-start/}Ocsigen Start}, which provides an application
+{{:https://ocsigen.org/ocsigen-start/}Ocsigen Start}, which provides an application
 template for quickly getting started with Ocsigen. The template
 provides various runnable examples of Ocsigen Toolkit widgets. See the
-{{:/ocsigen-start/latest/intro.html}Ocsigen Start
+{{:https://ocsigen.org/ocsigen-start/latest/intro.html}Ocsigen Start
 manual} for details.
 
 See the widgets in action in
-{{:/ocsigen-start/demo/}Ocsigen Start's demo application}
+{{:https://ocsigen.org/ocsigen-start/demo/}Ocsigen Start's demo application}
 (also available for Android and iOS, or in your mobile browser).
 
 {1 Programming style}
@@ -34,7 +34,7 @@ sections. The server instance of the code can be used to produce pages
 (with Ocsigen Toolkit widgets) during traditional Web interaction,
 while the client instance can be used to render the same pages and
 widgets on a mobile device without contacting the server. See the
-{{:/eliom/latest/mobile-apps.html}mobile applications
+{{:https://ocsigen.org/eliom/latest/mobile-apps.html}mobile applications
 section} of the Eliom manual for details.
 
 The widgets generally follow a reactive programming style. We use
@@ -42,7 +42,7 @@ The widgets generally follow a reactive programming style. We use
 extensively, which allows us to produce this reactive content on both
 sides.
 See
-{{:/eliom/latest/clientserver-react.html}the respective manual chapter}
+{{:https://ocsigen.org/eliom/latest/clientserver-react.html}the respective manual chapter}
 for more info.
 {!Eliom_shared}
 signals and events appear in the Ocsigen Toolkit APIs, and can be used

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -1,0 +1,109 @@
+{0 Introduction}
+
+Ocsigen Toolkit provides various user interface widgets and related
+utilities that assist in the rapid development of interactive Web
+applications.
+
+Ocsigen Toolkit is built with {{:../eliom}Eliom}.
+
+{1 Installation and getting started}
+
+You can install Ocsigen Toolkit via OPAM:
+
+{v
+opam install ocsigen-toolkit
+v}
+
+You may want to use Ocsigen Toolkit in conjunction with
+{{:../ocsigen-start}Ocsigen Start}, which provides an application
+template for quickly getting started with Ocsigen. The template
+provides various runnable examples of Ocsigen Toolkit widgets. See the
+{{:../ocsigen-start/intro.html}Ocsigen Start
+manual} for details.
+
+See the widgets in action in
+{{:../ocsigen-start/demo/}Ocsigen Start's demo application}
+(also available for Android and iOS, or in your mobile browser).
+
+{1 Programming style}
+
+Most of the Ocsigen Toolkit widgets can be produced invariably on the
+server or on the client (with the same code). This enables a
+mobile-friendly programming paradigm, where most code lies in shared
+sections. The server instance of the code can be used to produce pages
+(with Ocsigen Toolkit widgets) during traditional Web interaction,
+while the client instance can be used to render the same pages and
+widgets on a mobile device without contacting the server. See the
+{{:../eliom/mobile-apps.html}mobile applications
+section} of the Eliom manual for details.
+
+The widgets generally follow a reactive programming style. We use
+{!Eliom_shared}
+extensively, which allows us to produce this reactive content on both
+sides.
+See
+{{:../eliom/clientserver-react.html}the respective manual chapter}
+for more info.
+{!Eliom_shared}
+signals and events appear in the Ocsigen Toolkit APIs, and can be used
+as a mechanism for composing different widgets.
+
+{1 CSS}
+
+Most widgets need appropriate CSS to display properly. We provide
+default CSS files, normally installed in
+
+[~/.opam/${SWITCH}/share/ocsigen-toolkit/css/]
+
+Ocsigen Start uses these files by default. If your application does
+not use Ocsigen Start, you will need to include the CSS manually.
+
+Of course, you are free to modify the style to suit the desired look.
+
+{1 Widgets overview}
+
+- {!Ot_buttons}:
+  provides a dropdown menu widget
+- {!Ot_calendar}:
+  calendar widget, allowing the user to pick dates
+- {!Ot_carousel}:
+  container for blocks, only one of which is displayed at a time,
+  with various ways to move between them (buttons, swipe, keyboard arrows)
+- {!Ot_tongue}:
+  swipable element appearing from one side of the screen
+- {!Ot_color_picker}:
+  color picker widget
+- {!Ot_drawer}:
+  a drawer menu that typically appears on an edge of the screen.
+  It can  appear/disappear via buttons or by swiping.
+- {!Ot_picture_uploader}:
+  user interface for uploading pictures
+- {!Ot_popup}:
+  popup windows that can be controlled in various ways
+- {!Ot_range}:
+  widget for picking one among a range of values
+- {!Ot_spinner}:
+  a spinner that appears while we wait for "slow" HTML content to be
+  generated
+- {!Ot_swipe}:
+  make element swipeable on touch screens
+- {!Ot_time_picker}:
+  clock-like widget that allows the user to pick a time
+- {!Ot_toggle}:
+  binary toggle widget
+
+{2 Non-widget utilities}
+
+- {!Ot_nodeready}:
+  produces an Lwt thread allowing one to wait for a node to be
+  inserted in the DOM
+- {!Ot_noderesize}:
+  listen to element resize events
+- {!Ot_size}:
+  utilities to deal with DOM element dimensions
+- {!Ot_lib}:
+  functions useful for other widgets
+- {!Ot_sticky}:
+  make elements "sticky", i.e., do not let them go out of sight
+- {!Ot_style}:
+  an interface to [Window.getComputedStyle()]

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -4,7 +4,7 @@ Ocsigen Toolkit provides various user interface widgets and related
 utilities that assist in the rapid development of interactive Web
 applications.
 
-Ocsigen Toolkit is built with {{:../eliom}Eliom}.
+Ocsigen Toolkit is built with {{:/eliom/}Eliom}.
 
 {1 Installation and getting started}
 
@@ -15,14 +15,14 @@ opam install ocsigen-toolkit
 v}
 
 You may want to use Ocsigen Toolkit in conjunction with
-{{:../ocsigen-start}Ocsigen Start}, which provides an application
+{{:/ocsigen-start/}Ocsigen Start}, which provides an application
 template for quickly getting started with Ocsigen. The template
 provides various runnable examples of Ocsigen Toolkit widgets. See the
-{{:../ocsigen-start/intro.html}Ocsigen Start
+{{:/ocsigen-start/latest/intro.html}Ocsigen Start
 manual} for details.
 
 See the widgets in action in
-{{:../ocsigen-start/demo/}Ocsigen Start's demo application}
+{{:/ocsigen-start/demo/}Ocsigen Start's demo application}
 (also available for Android and iOS, or in your mobile browser).
 
 {1 Programming style}
@@ -34,7 +34,7 @@ sections. The server instance of the code can be used to produce pages
 (with Ocsigen Toolkit widgets) during traditional Web interaction,
 while the client instance can be used to render the same pages and
 widgets on a mobile device without contacting the server. See the
-{{:../eliom/mobile-apps.html}mobile applications
+{{:/eliom/latest/mobile-apps.html}mobile applications
 section} of the Eliom manual for details.
 
 The widgets generally follow a reactive programming style. We use
@@ -42,7 +42,7 @@ The widgets generally follow a reactive programming style. We use
 extensively, which allows us to produce this reactive content on both
 sides.
 See
-{{:../eliom/clientserver-react.html}the respective manual chapter}
+{{:/eliom/latest/clientserver-react.html}the respective manual chapter}
 for more info.
 {!Eliom_shared}
 signals and events appear in the Ocsigen Toolkit APIs, and can be used

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,31 @@
+;; Declarative wodoc config for the Ocsigen Toolkit documentation (client/server).
+;;   wodoc build --config doc/wodoc --out <dir>/<label> --label <v> \
+;;               --menu https://ocsigen.org/doc/menu.html [--local]
+;; ocsigen-toolkit ships server and client libraries (ocsigen-toolkit.server /
+;; ocsigen-toolkit.client) with the same module names, so the API is built with
+;; `odoc_driver ocsigen-toolkit --remap` on the INSTALLED package. This is the
+;; master (stable) documentation: modules are FLAT (Ot_*), so no wrapper. Each
+;; side gets its own API nav, a body colour and a switch; the manual nav is shared.
+(project ocsigen-toolkit)
+(title Toolkit)
+(pub /ocsigen-toolkit)
+(odoc-driver ocsigen-toolkit)
+(landing intro.html)
+
+;; The shared manual nav (only `dev` is ever rebuilt, so this static nav always
+;; matches the current manual; released versions keep the nav they were frozen with).
+(nav
+ (section "Ocsigen Toolkit"
+  (link "Introduction" intro.html intro)))
+
+(client-server
+  (server (lib ocsigen-toolkit.server) (heading "Server API"))
+  (client (lib ocsigen-toolkit.client) (heading "Client API")))
+
+;; Sibling Ocsigen projects whose ocaml.org xrefs are rewritten to relative
+;; links into their wodoc docs:  (pkg deploy-dir multi-library? wrapper-module)
+(hosted
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen))


### PR DESCRIPTION
Adds the Ocsigen Toolkit documentation (manual) as odoc `.mld` pages, built
in-package with the API so the whole doc is generated by odoc/`dune build @doc`
and ships on ocaml.org — part of the ocsigen.org → wodoc/odoc migration.

This is the **stable** branch (off `master`, v4.2.0, flat `Ot_xxx` modules).

**Changes**
- `doc/intro.mld` — the manual introduction, converted from the wikicreole
  source (`wikidoc:doc/2.7.0/manual/intro.wiki`) with `wodoc convert --odoc-refs`.
  Cross-package API references use native odoc refs (`{!Ot_popup}`,
  `{!Eliom_shared}`); cross-project links are relative; the removed
  `Ot_social_meta` entry was dropped.
- `doc/index.mld` — package landing page (overview + link to the manual).
- `doc/dune` — `(documentation (package ocsigen-toolkit))` so the `.mld` are
  compiled in the same odoc run as the API and `{{!page-X}}` / `{!Module}`
  references resolve.

The themed HTML is built by `ocsigen.github.io:wodoc/ocsigen-toolkit/build.sh`
(patched odoc-driver, since the server/client libraries share module names) and
is previewed at https://ocsigen.org/wodoc/ocsigen-toolkit/latest/ .

Draft until the wider wodoc rollout is finalised.
