### PR TITLE
ci: cancel superseded CI runs (add concurrency group)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
The org's CI shares a single pool of GitHub-hosted runners (free plan, ~20
concurrent jobs across **all** repos). With many open PRs and large build
matrices, runs were piling up: every new push stacked another full run on top
of the previous one, which kept **queued** instead of being cancelled. Plain
`ubuntu-latest` jobs ended up waiting for hours, starving every other repo.

This adds a `concurrency` group so a new push to a PR cancels the superseded,
still-running run for that same ref. Cancellation is scoped to
`pull_request` events only, so pushes/deploys on the default branch are never
cancelled.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```