### PR TITLE
doc: order the sidebar and make index.mld the landing page (for ocaml.org)

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,3 +1,5 @@
+@children_order intro
+
 {0 Ocsigen Toolkit}
 
 Ocsigen Toolkit is a set of reusable user-interface widgets for

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -9,7 +9,7 @@
 (title Toolkit)
 (pub /ocsigen-toolkit)
 (odoc-driver ocsigen-toolkit)
-(landing intro.html)
+(landing index.html)
 (nav
  (section "Ocsigen Toolkit"
   (link "Introduction" intro.html intro)))


### PR DESCRIPTION
Part of an effort to make the Ocsigen documentation complete and well-formed on ocaml.org (picked up at the next release). Targets `modernize`.

`doc/index.mld` already is the package home page (it introduces Ocsigen Toolkit and links to the introduction and the API). This:

- adds `@children_order intro` so the introduction appears before the API modules in the ocaml.org sidebar (instead of the alphabetical default);
- points the ocsigen.org landing (`doc/wodoc`) at `index.html` instead of `intro.html`, so both sites use the same home page.

## Verification

Standalone `odoc compile` of `index.mld` succeeds (frontmatter + markup parse cleanly). Toolkit is a client/server project built with odoc_driver (not plain `dune @doc`).