### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -8,8 +8,8 @@
 ;; side gets its own API nav, a body colour and a switch; the manual nav is shared.
 (project ocsigen-toolkit)
 (title Toolkit)
-(pub /ocsigen-toolkit)
-(odoc-driver ocsigen-toolkit)
+(url-prefix /ocsigen-toolkit)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing intro.html)
 
 ;; The shared manual nav (only `dev` is ever rebuilt, so this static nav always


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc):

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme);
- rename `(pub …)` → `(url-prefix …)`;
- drop the now-redundant `(odoc-driver …)` — implied by `(client-server …)` in wodoc 1.0.

The doc CI tracks wodoc master, so no CI change is needed.

Note: opened from origin/master; may need a rebase against the in-flight doc refactor branch.