### PR TITLE
doc: quote hyphenated page names in cross-project references

### DIFF
--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -34,7 +34,7 @@ sections. The server instance of the code can be used to produce pages
 (with Ocsigen Toolkit widgets) during traditional Web interaction,
 while the client instance can be used to render the same pages and
 widgets on a mobile device without contacting the server. See the
-{{!/eliom/page-mobile-apps}mobile applications
+{{!/eliom/page-"mobile-apps"}mobile applications
 section} of the Eliom manual for details.
 
 The widgets generally follow a reactive programming style. We use
@@ -42,7 +42,7 @@ The widgets generally follow a reactive programming style. We use
 extensively, which allows us to produce this reactive content on both
 sides.
 See
-{{!/eliom/page-clientserver-react}the respective manual chapter}
+{{!/eliom/page-"clientserver-react"}the respective manual chapter}
 for more info.
 {!Eliom_shared}
 signals and events appear in the Ocsigen Toolkit APIs, and can be used


### PR DESCRIPTION
odoc cannot parse a **hyphenated** page name in a path reference: `{{!/eliom/page-mobile-apps}}` produces "Unknown reference qualifier" and renders as plain text (no link). It must be quoted: `{{!/eliom/page-"mobile-apps"}}`. This quotes the hyphenated cross-project page references introduced earlier (they were silently broken). Verified: pages now compile with no reference-qualifier error.