### PR TITLE
doc: port cross-project link conversion to modernize

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,7 +1,7 @@
 {0 Ocsigen Toolkit}
 
 Ocsigen Toolkit is a set of reusable user-interface widgets for
-{{:/eliom/}Eliom} applications. The widgets can be produced on the
+{{!/eliom/page-index}Eliom} applications. The widgets can be produced on the
 server or on the client from the same code, which makes them
 particularly suited to mobile, client-server applications.
 
@@ -16,10 +16,10 @@ opam install ocsigen-toolkit
 ]}
 
 You may want to use Ocsigen Toolkit in conjunction with
-{{:/ocsigen-start/}Ocsigen Start}, which provides an application
+{{!/ocsigen-start/page-index}Ocsigen Start}, which provides an application
 template for quickly getting started with Ocsigen. The template
 provides various runnable examples of Ocsigen Toolkit widgets. See the
-{{:/ocsigen-start/latest/intro.html}Ocsigen Start
+{{!/ocsigen-start/page-index}Ocsigen Start
 manual} for details.
 
 {1 Programming style}
@@ -31,7 +31,7 @@ sections. The server instance of the code can be used to produce pages
 (with Ocsigen Toolkit widgets) during traditional Web interaction,
 while the client instance can be used to render the same pages and
 widgets on a mobile device without contacting the server. See the
-{{:/eliom/latest/mobile-apps.html}mobile applications
+{{!/eliom/page-"mobile-apps"}mobile applications
 section} of the Eliom manual for details.
 
 The widgets generally follow a reactive programming style. We use
@@ -39,7 +39,7 @@ The widgets generally follow a reactive programming style. We use
 extensively, which allows us to produce this reactive content on both
 sides.
 See
-{{:/eliom/latest/clientserver-react.html}the respective manual chapter}
+{{!/eliom/page-"clientserver-react"}the respective manual chapter}
 for more info.
 {!Eliom.Shared}
 signals and events appear in the Ocsigen Toolkit APIs, and can be used


### PR DESCRIPTION
Ports the master cross-project-links work (toolkit#258/#259) onto the `modernize` branch so merging it later does not reintroduce the old links. Converts the root-relative `{{:/eliom/…}}` / `{{:/ocsigen-start/…}}` links to odoc references `{{!/pkg/page-…}}` (hyphenated names quoted), matching master. Compiles with no reference-qualifier errors.