### PR TITLE
Adapt to Ocsigen Server 8 (+ ocamlformat 0.29)

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.28.1
+version=0.29.0
 parse-docstrings = false
 break-cases = fit
 break-collection-expressions = fit-or-vertical

--- a/doc/dune
+++ b/doc/dune
@@ -1,5 +1,6 @@
 ; Ocsigen Toolkit manual pages (odoc .mld), compiled in place with the API by
 ; `dune build @doc` and installed with the package, so they appear on ocaml.org
 ; and resolve {{!page-X}} / {!Module} references against the API.
+
 (documentation
  (package ocsigen-toolkit))

--- a/src/compat/client/dune
+++ b/src/compat/client/dune
@@ -4,5 +4,6 @@
  (synopsis "Backward-compatible Ot_xxx module names (client-side)")
  (wrapped false)
  (modes byte)
- (flags (:standard -w -70))
+ (flags
+  (:standard -w -70))
  (libraries ocsigen-toolkit.client))

--- a/src/compat/server/dune
+++ b/src/compat/server/dune
@@ -3,5 +3,6 @@
  (public_name ocsigen-toolkit-compat.server)
  (synopsis "Backward-compatible Ot_xxx module names (server-side)")
  (wrapped false)
- (flags (:standard -w -70))
+ (flags
+  (:standard -w -70))
  (libraries ocsigen-toolkit.server))

--- a/src/widgets/Ot/calendar.eliom
+++ b/src/widgets/Ot/calendar.eliom
@@ -179,11 +179,11 @@ let select_action ?(size = 1) selector action =
       Lwt.return_unit))
 
 let build_calendar
-          ?prehilight
-          ~button_labels:{b_prev_year; b_prev_month; b_next_month; b_next_year}
-          ~intl
-          ~period
-          day
+      ?prehilight
+      ~button_labels:{b_prev_year; b_prev_month; b_next_month; b_next_year}
+      ~intl
+      ~period
+      day
   =
   let today = CalendarLib.Date.today () in
   let fst_dow = fst_dow ~intl day

--- a/src/widgets/Ot/carousel.eliom
+++ b/src/widgets/Ot/carousel.eliom
@@ -230,7 +230,7 @@ let%shared
              | `No_header -> Some 0
              | `Header (f : unit -> int) -> Some (f ())
            in
-           Eliom.Lib.Option.iter
+           Option.iter
              (fun dist ->
                 let delta = max 0 (dist - int_of_float (Size.client_top d)) in
                 let pos = React.S.value pos_signal in
@@ -262,7 +262,7 @@ let%shared
            | `No_header, _ -> Some 0
            | `Header (f : unit -> int), _ -> Some (f ())
          in
-         Eliom.Lib.Option.iter
+         Option.iter
            (fun dist ->
               let delta = -max 0 (dist - int_of_float (Size.client_top d)) in
               let pos = React.S.value pos_signal in
@@ -310,7 +310,7 @@ let%shared
                Lwt.return_unit
              else Lwt.return_unit
            in
-           Eliom.Lib.Option.iter (fun f -> f ()) transitionend;
+           Option.iter (fun f -> f ()) transitionend;
            Manip.Class.remove ~%d2 ot_swiping;
            ~%pos_post_set pos;
            (* Remove swiping after calling f,
@@ -513,7 +513,7 @@ let%shared
          Lwt.async (fun () -> Lwt_js_events.touchends d touchend);
          Lwt.async (fun () -> Lwt_js_events.touchcancels d touchcancel));
        ignore
-         (Eliom.Lib.Option.map
+         (Option.map
             (fun update ->
                Eliom.Lib.Dom_reference.retain d
                  ~keep:
@@ -749,9 +749,7 @@ let%shared
   let nb_pages = List.length l in
   let the_ul = D.ul ~a:[a_class ["ot-car-ribbon-list"]] l in
   let cursor_elt =
-    Eliom.Lib.Option.map
-      (fun _ -> D.div ~a:[a_class ["ot-car-cursor"]] [])
-      cursor
+    Option.map (fun _ -> D.div ~a:[a_class ["ot-car-cursor"]] []) cursor
   in
   let cursor_l = match cursor_elt with None -> [] | Some c -> [c] in
   let container =
@@ -766,7 +764,7 @@ let%shared
        let container' = To_dom.of_element container in
        let initial_gap = ~%initial_gap in
        let the_ul' = To_dom.of_element the_ul in
-       let cursor_elt' = Eliom.Lib.Option.map To_dom.of_element ~%cursor_elt in
+       let cursor_elt' = Option.map To_dom.of_element ~%cursor_elt in
        let containerwidth, set_containerwidth =
          React.S.create container'##.offsetWidth
        in
@@ -854,11 +852,11 @@ let%shared
                          (* Carousel is being swiped.
                       Removing transition on cursor. *)
                          moving := true;
-                         Eliom.Lib.Option.iter remove_transition cursor_elt');
+                         Option.iter remove_transition cursor_elt');
                        if offset = 0. && !moving
                        then (
                          moving := false;
-                         Eliom.Lib.Option.iter add_transition cursor_elt');
+                         Option.iter add_transition cursor_elt');
                        let firstselectedelt = Manip.nth the_ul pos in
                        let lastselectedelt =
                          Manip.nth the_ul (pos + size - 1)
@@ -927,7 +925,7 @@ let%shared
          let* () = Nodeready.nodeready container' in
          let* () = Lwt_js_events.request_animation_frame () in
          add_transition the_ul';
-         Eliom.Lib.Option.iter add_transition cursor_elt';
+         Option.iter add_transition cursor_elt';
          Lwt.return_unit);
        (* Moving the ribbon with fingers: *)
        let fmax () = initial_gap in
@@ -952,9 +950,8 @@ let%shared
            let pos = min (fmax ()) pos in
            let pos = max (fmin ()) pos in
            set_curleft pos)
-         ~onstart:(fun _ _ ->
-           Eliom.Lib.Option.iter remove_transition cursor_elt')
-         ~onend:(fun ev _ -> Eliom.Lib.Option.iter add_transition cursor_elt')
+         ~onstart:(fun _ _ -> Option.iter remove_transition cursor_elt')
+         ~onend:(fun ev _ -> Option.iter add_transition cursor_elt')
          the_ul;
        Lwt.return_unit
        : _)];

--- a/src/widgets/Ot/drawer.eliom
+++ b/src/widgets/Ot/drawer.eliom
@@ -143,7 +143,7 @@ let%shared
          Lwt_js_events.async (fun () ->
            let* _ = Lwt_js_events.transitionend (To_dom.of_element ~%d) in
            remove_class ~%bckgrnd "closing";
-           Eliom.Lib.Option.iter (fun f -> f ()) ~%onclose;
+           Option.iter (fun f -> f ()) ~%onclose;
            Lwt.return_unit)
        : unit -> unit)]
   in
@@ -153,7 +153,7 @@ let%shared
       (fun () ->
          ~%scroll_pos := Js.to_float Dom_html.window##.scrollY;
          add_class ~%bckgrnd "open";
-         Eliom.Lib.Option.iter (fun f -> f ()) ~%onopen;
+         Option.iter (fun f -> f ()) ~%onopen;
          Dom_html.document##.body##.style##.top
          := Js.string (Printf.sprintf "%.2fpx" (-. !(~%scroll_pos)));
          add_class ~%bckgrnd "opening";

--- a/src/widgets/Ot/icons.eliom
+++ b/src/widgets/Ot/icons.eliom
@@ -14,15 +14,8 @@ module type S = sig
     -> unit
     -> [> Html_types.i] elt
 
-  val user :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
-
-  val plus :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
+  val user : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
+  val plus : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
 
   val spinner :
      ?a:Html_types.i_attrib attrib list
@@ -44,10 +37,7 @@ module type S = sig
     -> unit
     -> [> Html_types.i] elt
 
-  val close :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
+  val close : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
 
   val question :
      ?a:Html_types.i_attrib attrib list

--- a/src/widgets/Ot/icons.eliomi
+++ b/src/widgets/Ot/icons.eliomi
@@ -41,66 +41,57 @@ module type S = sig
   type 'a elt
   type 'a attrib
 
-  (** [icon classes ()] is an empty [<i>] element whose CSS classes
-      are ["ot-icon"] followed by [classes]. The optional [?a]
-      argument lets the caller add extra attributes (typically more
-      classes). It comes last so that the predefined icons below can
-      be partially applied and still expose [?a]. *)
   val icon :
      string list
     -> ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** [icon classes ()] is an empty [<i>] element whose CSS classes
+      are ["ot-icon"] followed by [classes]. The optional [?a]
+      argument lets the caller add extra attributes (typically more
+      classes). It comes last so that the predefined icons below can
+      be partially applied and still expose [?a]. *)
 
+  val user : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
   (** Predefined icon for a user / profile glyph
       (CSS class [ot-icon-user]). *)
-  val user :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
 
+  val plus : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
   (** Predefined "plus" / add icon (CSS class [ot-plus]). *)
-  val plus :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
 
-  (** Animated spinner icon
-      (CSS classes [ot-icon-spinner ot-icon-animation-spinning]). *)
   val spinner :
      ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** Animated spinner icon
+      (CSS classes [ot-icon-spinner ot-icon-animation-spinning]). *)
 
-  (** Shutdown / power icon (CSS class [ot-icon-power]). *)
   val shutdown :
      ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** Shutdown / power icon (CSS class [ot-icon-power]). *)
 
-  (** Configuration / gear icon (CSS class [ot-icon-gear]). *)
   val config :
      ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** Configuration / gear icon (CSS class [ot-icon-gear]). *)
 
-  (** Sign out / logout icon (CSS class [ot-icon-sign-out]). *)
   val signout :
      ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** Sign out / logout icon (CSS class [ot-icon-sign-out]). *)
 
+  val close : ?a:Html_types.i_attrib attrib list -> unit -> [> Html_types.i] elt
   (** Close icon (CSS class [ot-icon-close]). *)
-  val close :
-     ?a:Html_types.i_attrib attrib list
-    -> unit
-    -> [> Html_types.i] elt
 
-  (** Question mark / help icon (CSS class [ot-icon-question]). *)
   val question :
      ?a:Html_types.i_attrib attrib list
     -> unit
     -> [> Html_types.i] elt
+  (** Question mark / help icon (CSS class [ot-icon-question]). *)
 end
 
 (** Build an icon module on top of an Eliom HTML implementation
@@ -109,12 +100,14 @@ module Make (A : Eliom.Content.Html.T) :
   S with type 'a elt = 'a A.elt and type 'a attrib = 'a A.attrib
 
 (** Icons built with {!Eliom.Content.Html.F} (static HTML). *)
-module F : S
+module F :
+  S
   with type 'a elt = 'a Eliom.Content.Html.F.elt
    and type 'a attrib = 'a Eliom.Content.Html.F.attrib
 
 (** Icons built with {!Eliom.Content.Html.D} (HTML with DOM identity,
     suitable for being referenced from client-side code). *)
-module D : S
+module D :
+  S
   with type 'a elt = 'a Eliom.Content.Html.D.elt
    and type 'a attrib = 'a Eliom.Content.Html.D.attrib

--- a/src/widgets/Ot/picture_uploader.eliom
+++ b/src/widgets/Ot/picture_uploader.eliom
@@ -416,13 +416,13 @@ let%client loads ?cancel_handler ?use_capture t =
 
 let%client bind_input input preview ?container ?reset () =
   let onerror () =
-    Eliom.Lib.Option.iter
+    Option.iter
       (fun container -> container##.classList##add (Js.string "ot-no-file"))
       container;
     preview##.src := Js.string "";
     Lwt.return_unit
   in
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun f ->
        Lwt.async (fun () -> loads preview (fun _ _ -> Lwt.return @@ f ())))
     reset;
@@ -435,7 +435,7 @@ let%client bind_input input preview ?container ?reset () =
            let () =
              file_reader (Js.Unsafe.coerce file) (fun data ->
                preview##.src := data;
-               Eliom.Lib.Option.iter
+               Option.iter
                  (fun container ->
                     container##.classList##remove (Js.string "ot-no-file"))
                  container)
@@ -453,7 +453,7 @@ type 'a upload =
 
 let%client ocaml_service_upload ~service ~arg ?progress ?cropping file =
   Eliom.Client.call_ocaml_service ~service () ?upload_progress:progress
-    (arg, (Eliom.Lib.Option.map React.S.value cropping, file))
+    (arg, (Option.map React.S.value cropping, file))
 
 let%client do_submit input ?progress ?cropping ~upload () =
   process_file input @@ fun file ->

--- a/src/widgets/Ot/popup.eliom
+++ b/src/widgets/Ot/popup.eliom
@@ -91,7 +91,7 @@ let%client
       (Dom_html.document##getElementsByClassName (Js.string "ot-popup"))##.length
       = 1
     then reset ();
-    let () = Eliom.Lib.Option.iter Manip.removeSelf !popup in
+    let () = Option.iter Manip.removeSelf !popup in
     stop_thread (); onclose ()
   in
   Eliom.Client.Page_status.oninactive ~stop reset;

--- a/src/widgets/Ot/pulltorefresh.eliom
+++ b/src/widgets/Ot/pulltorefresh.eliom
@@ -205,8 +205,7 @@ let make
            let timeout = ~%refresh_timeout
            let container = ~%container
            let afterPull = ~%afterPull
-         end
-         in
+         end in
          let module Ptr = Make (Ptr_conf) in
          Ptr.init ()
          : unit)];

--- a/src/widgets/Ot/swipe.eliom
+++ b/src/widgets/Ot/swipe.eliom
@@ -128,7 +128,7 @@ let%shared
            add_transition ~%transition_duration elt';
            let left = ~%compute_final_pos ev (truncate (clX ev -. !startx)) in
            elt'##.style##.left := px_of_int left;
-           Eliom.Lib.Option.iter (fun f -> f ev left) ~%onend;
+           Option.iter (fun f -> f ev left) ~%onend;
            Lwt.async (fun () ->
              let* _ = Lwt_js_events.transitionend elt' in
              Manip.Class.remove elt "ot-swiping";
@@ -156,13 +156,13 @@ let%shared
                (* We decide to take the event *)
                Manip.Class.add elt "ot-swiping";
                remove_transition elt';
-               Eliom.Lib.Option.iter (fun f -> f ev (truncate left)) ~%onstart;
+               Option.iter (fun f -> f ev (truncate left)) ~%onstart;
                (* We send a touchcancel to the parent (who received the start) *)
                dispatch_event ~ev elt' "touchcancel" (clX ev) (clY ev);
                In_progress)
              else !status;
-         let min = Eliom.Lib.Option.map (fun f -> f ()) ~%min in
-         let max = Eliom.Lib.Option.map (fun f -> f ()) ~%max in
+         let min = Option.map (fun f -> f ()) ~%min in
+         let max = Option.map (fun f -> f ()) ~%max in
          if !status = In_progress
          then (
            match min, max with
@@ -171,7 +171,7 @@ let%shared
                     We stop the movement of this element
                     and dispatch it to the parent. *)
                status := Below;
-               Eliom.Lib.Option.iter (fun f -> f ev min) ~%onmove;
+               Option.iter (fun f -> f ev min) ~%onmove;
                do_pan min;
                (* We send a touchstart event to the parent *)
                dispatch_event ~ev elt' "touchstart"
@@ -184,7 +184,7 @@ let%shared
                     We stop the movement of this element
                     and dispatch it to the parent. *)
                status := Above;
-               Eliom.Lib.Option.iter (fun f -> f ev max) ~%onmove;
+               Option.iter (fun f -> f ev max) ~%onmove;
                do_pan max;
                (* We send a touchstart event to the parent *)
                dispatch_event ~ev elt' "touchstart"
@@ -195,7 +195,7 @@ let%shared
            | _ ->
                Dom_html.stopPropagation ev;
                Dom.preventDefault ev;
-               Eliom.Lib.Option.iter (fun f -> f ev (truncate left)) ~%onmove;
+               Option.iter (fun f -> f ev (truncate left)) ~%onmove;
                do_pan (int_of_float (left +. 0.5));
                Lwt.return_unit)
          else

--- a/src/widgets/Ot/swipe.eliom
+++ b/src/widgets/Ot/swipe.eliom
@@ -49,12 +49,12 @@ let%client dispatch_event ~ev elt name x y =
         let touch = Js.Unsafe.global##.Touch in
         let touch =
           new%js touch
-            (object%js
-               val identifier = identifier ev
-               val target = target
-               val clientX = x
-               val clientY = y
-            end)
+            object%js
+              val identifier = identifier ev
+              val target = target
+              val clientX = x
+              val clientY = y
+            end
         in
         if touch##.target = Js.null then failwith "new Touch() not supported";
         let opt =


### PR DESCRIPTION
Makes ocsigen-toolkit build against Eliom 13 / Ocsigen Server 8.

Two commits:
1. **Switch to ocamlformat 0.29.0** — match the version already used in practice (pinned in eliom/ocsigen-start); reformat a few stragglers. Fixes the pre-existing red `lint-fmt` on `modernize`.
2. **Adapt to Server 8: use stdlib Option** — `Eliom.Lib.Option` (which re-exported the Ocsigen Server baselib `Option`, removed in Server 8) → stdlib `Option` (25 uses; map/iter identical signatures). The only local `module Option` (page_transition.eliom) does not use it, so no collision.

Testing: `dune build @install` and `dune build @fmt` clean against eliom.13.0~dev.