### PR TITLE
Release 4.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,11 @@ jobs:
       # Pin dune below 3.24. dune 3.24 changed dune-variable paths to a
       # leading-"./" form (ocaml/dune#15156), which makes the wasm_of_ocaml
       # runtime (pulled in via eliom) emit malformed "module:path" lines and
-      # fail to build with "The runtime contains unknown imports". The fix
-      # only landed in js_of_ocaml 6.4.1 (ocsigen/js_of_ocaml#2371), but we
-      # cap js_of_ocaml below 6.4 (see the opam file), so the 6.3.x wasm
-      # runtime -- which has the same bug -- still needs an older dune.
+      # fail to build with "The runtime contains unknown imports". We now
+      # require js_of_ocaml >= 6.4.0 (see the opam file), whose wasm runtime
+      # still has this bug; it is fixed only in js_of_ocaml 6.4.1
+      # (ocsigen/js_of_ocaml#2371), not yet in the opam repository. Drop this
+      # pin once 6.4.1 is available.
       - run: opam pin add -n dune 3.23.1
 
       - run: opam install . --deps-only

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           # Pin dune below 3.24. dune 3.24's leading-"./" path form
           # (ocaml/dune#15156) breaks the wasm_of_ocaml runtime build ("The
-          # runtime contains unknown imports"). The upstream fix is in
-          # js_of_ocaml 6.4.1 (ocsigen/js_of_ocaml#2371), but we cap
-          # js_of_ocaml below 6.4, and the 6.3.x wasm runtime has the same
-          # bug, so it still needs an older dune.
+          # runtime contains unknown imports"). We now require js_of_ocaml
+          # >= 6.4.0, whose wasm runtime still has this bug; the upstream fix
+          # is in js_of_ocaml 6.4.1 (ocsigen/js_of_ocaml#2371), not yet in the
+          # opam repository. Drop this pin once 6.4.1 is available.
           opam pin add -n dune 3.23.1
           opam install . --deps-only --with-doc
           # wodoc themes the pages. Its opam pin-depends pulls odoc / odoc-driver

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
-===== unreleased =====
+===== 4.3.0 (2026-07-02) =====
 * Ot_picture_uploader: fix build with js_of_ocaml >= 6.4.0, where
-  inputElement##.files is now a nullable File.fileList Js.t Js.opt
+  inputElement##.files is now a nullable File.fileList Js.t Js.opt.
+  js_of_ocaml >= 6.4.0 is now required.
+* Declare lwt_ppx as an explicit dependency (previously pulled in
+  transitively).
 
 ===== 4.1.0 =====
 * Compatibility with WASM


### PR DESCRIPTION
Release **4.3.0**, cut to ship the js_of_ocaml 6.4 build fix (#267).

## Changes since 4.2.0
- **Ot_picture_uploader**: build fix for js_of_ocaml >= 6.4.0 (nullable `inputElement##.files`), merged in #267. `js_of_ocaml >= 6.4.0` is now required.
- **lwt_ppx** declared as an explicit dependency (#268), previously pulled in transitively.

## This PR
- `CHANGES`: turn the `unreleased` section into `4.3.0 (2026-07-02)` and note the jsoo requirement bump + lwt_ppx.
- **CI cleanup**: #267 removed the `js_of_ocaml < 6.4` cap but left the dune-pin comments in `build.yml` / `doc.yml` describing the old '6.3.x / capped below 6.4' rationale. Refresh them: the `dune 3.23.1` pin is still needed (the wasm runtime bug persists on 6.4.0, fixed only in the not-yet-released 6.4.1), but the justification now reflects `>= 6.4.0`. No command change.

The tag is pushed after merge, then the package is published to opam.