### PR TITLE
Fix untyped JS reads that trap ("bad cast") under wasm_of_ocaml

### DIFF
--- a/src/widgets/ot_form.eliom
+++ b/src/widgets/ot_form.eliom
@@ -47,7 +47,10 @@ let%client set_validity e b =
 
 let%client valid e =
   try
-    (Js.Unsafe.coerce e)##checkValidity
+    (* [checkValidity] returns a JS boolean: convert it. Under
+       wasm_of_ocaml, using it directly as an OCaml [bool] traps with
+       "bad cast" (JS booleans cross the FFI boundary as opaque values). *)
+    Js.to_bool (Js.Unsafe.coerce e)##checkValidity
     && not (Js.to_bool (e##.classList##contains (Js.string "ot-invalid")))
   with _ -> true
 
@@ -578,7 +581,9 @@ let%shared
   ignore
   @@ [%client
        (let inp = Eliom_content.Html.To_dom.of_input ~%inp in
-        let f () = set_validity inp (Js.Unsafe.coerce inp)##checkValidity in
+        let f () =
+          set_validity inp (Js.to_bool (Js.Unsafe.coerce inp)##checkValidity)
+        in
         Lwt.async @@ fun () ->
         let* _ = Lwt_js_events.blur inp in
         f ();

--- a/src/widgets/ot_popup.eliom
+++ b/src/widgets/ot_popup.eliom
@@ -52,18 +52,24 @@ let%client disable_page_scroll, enable_page_scroll =
   ( (fun () ->
       if !scroll_pos = None
       then (
-        let pos = (Js.Unsafe.coerce Dom_html.window)##.pageYOffset in
+        (* [pageYOffset] is a float (it is fractional whenever the device
+           pixel ratio is): read it as a JS number. Under wasm_of_ocaml,
+           reading it directly as an [int] traps with "bad cast" as soon
+           as the value is fractional. *)
+        let pos =
+          Js.float_of_number (Js.Unsafe.coerce Dom_html.window)##.pageYOffset
+        in
         scroll_pos := Some pos;
         html_ManipClass_add (html ()) "ot-with-popup";
         Dom_html.document##.body##.style##.top
-        := Js.string (Printf.sprintf "%dpx" (-pos))))
+        := Js.string (Printf.sprintf "%gpx" (-.pos))))
   , fun () ->
       match !scroll_pos with
       | None -> ()
       | Some pos ->
           html_ManipClass_remove (html ()) "ot-with-popup";
           Dom_html.document##.body##.style##.top := Js.string "";
-          Dom_html.window##scrollTo (Js.float 0.) (Js.float (float pos));
+          Dom_html.window##scrollTo (Js.float 0.) (Js.float pos);
           scroll_pos := None )
 
 let%client

--- a/src/widgets/ot_size.eliom
+++ b/src/widgets/ot_size.eliom
@@ -137,8 +137,14 @@ let pageYOffset () =
     Dom_html.document##.documentElement##.clientHeight
   in
   (* on some browsers innerHeight is not available -> fall back to clientHeight *)
+  (* [innerHeight] and [pageYOffset] are floats (fractional whenever the
+     device pixel ratio is): read them as JS numbers. Under wasm_of_ocaml,
+     reading them directly as [int]s traps with "bad cast" as soon as the
+     value is fractional. *)
   let get_innerHeight () =
-    try (Js.Unsafe.coerce Dom_html.window)##.innerHeight
+    try
+      int_of_float
+        (Js.float_of_number (Js.Unsafe.coerce Dom_html.window)##.innerHeight)
     with _ -> get_clientHeight ()
   in
   max 0
@@ -146,4 +152,5 @@ let pageYOffset () =
   (* overscroll at the top *)
   min (* overscroll at the bottom *)
     (Dom_html.document##.documentElement##.scrollHeight - get_innerHeight ())
-    (Js.Unsafe.coerce Dom_html.window)##.pageYOffset
+    (int_of_float
+       (Js.float_of_number (Js.Unsafe.coerce Dom_html.window)##.pageYOffset))


### PR DESCRIPTION
## Summary

Under **wasm_of_ocaml**, every `Ot_popup.confirm` / `ask_question` dialog crashes with an uncaught `RuntimeError: bad cast` on hidpi displays (device pixel ratio 2, or any fractional dpr) as soon as the page is scrolled. This PR fixes the root cause plus two other occurrences of the same bug class found by auditing the widgets.

## Root cause

`Ot_popup.disable_page_scroll` reads the scroll position through an untyped FFI access whose result is *inferred* as `int`:

```ocaml
let pos = (Js.Unsafe.coerce Dom_html.window)##.pageYOffset in
... Printf.sprintf "%dpx" (-pos)
```

At the wasm_of_ocaml FFI boundary, a JS number is converted **by value**: an *integral* number becomes an OCaml `int` (i31), but a *fractional* one crosses as an opaque JS value. The generated code then executes `ref.cast (ref i31)` on it and **traps**.

`window.pageYOffset` is fractional exactly when the display has a device pixel ratio: on a dpr=2 screen, scroll offsets land on half CSS pixels (e.g. `801.5`). So the trap is value-dependent, which made it look browser-specific — Firefox reports true fractional scroll offsets on hidpi displays, while Chromium rounds them to integers — and it never reproduced in minimal test apps (which click buttons at `pageYOffset = 0`).

Observed trap (Firefox 152, dpr=2, wasm frame stack):

```
RuntimeError: bad cast
  disable_page_scroll@...widgets_client-*.wasm
  onactive@...eliom_client-*.wasm
  popup / ask_question / ...
```

## Fixes

The correct idiom is to convert through the typed JS number/bool API — `Js.float_of_number` compiles to `caml_js_to_float`, which handles the value whatever its boundary representation:

- **`Ot_popup.disable_page_scroll`**: read `pageYOffset` with `Js.float_of_number` and keep it as a `float` end-to-end (`%gpx`). Bonus: the restored scroll position no longer loses the fractional part.
- **`Ot_size.pageYOffset`**: `innerHeight` and `pageYOffset` converted with `float_of_number` + `int_of_float` (both can be fractional on hidpi displays).
- **`Ot_form.valid`** and **`graceful_invalid_style`**: `checkValidity` returns a JS boolean, which also crosses the wasm FFI boundary as an opaque value; convert it with `Js.to_bool`. (In `valid` the trap was masked by the surrounding `try ... with _ -> true`, silently disabling validation under wasm.)

A survey of the remaining `Js.Unsafe` uses in the widgets found no other unsafe numeric/boolean reads (the rest are string properties and argument-passing, which are safe).

## Validation

Reproduced and validated on a real Eliom/Ocsigen Start application compiled with wasm_of_ocaml 6.4:

- before: windowed Firefox 152 at dpr=2, page scrolled to `pageYOffset = 801.5`, opening a confirm dialog → `bad cast` trap, popup never appears (deterministic);
- after: same scenario → popup opens, `body.style.top = "-801.5px"`, closing restores the scroll position to exactly `801.5`, zero console errors.

The same fix is needed on the `jsoo-6.4` branch; the equivalent commit for that layout exists and can be cherry-picked (`src/widgets/Ot/{popup,size,form}.eliom`).

## General note

Any `Js.Unsafe.coerce` read whose result type is inferred as `int`, `bool` or `float` is a latent wasm trap of this kind: it works in every test until a hidpi display or a browser zoom hands the code a fractional number. Writes and string-typed reads are unaffected.
